### PR TITLE
rename stride/range to strides/ranges

### DIFF
--- a/lake/models/addr_gen_model.py
+++ b/lake/models/addr_gen_model.py
@@ -18,8 +18,8 @@ class AddrGenModel(Model):
         self.address = 0
 
         for i in range(self.iterator_support):
-            self.config[f"range_{i}"] = 0
-            self.config[f"stride_{i}"] = 0
+            self.config[f"ranges_{i}"] = 0
+            self.config[f"strides_{i}"] = 0
             self.dim_cnt.append(0)
 
     def set_config(self, new_config):
@@ -42,7 +42,7 @@ class AddrGenModel(Model):
 
             if update_curr:
                 self.dim_cnt[i] = self.dim_cnt[i] + 1
-                if(self.dim_cnt[i] == self.config[f"range_{i}"]):
+                if(self.dim_cnt[i] == self.config[f"ranges_{i}"]):
                     self.dim_cnt[i] = 0
                 else:
                     break
@@ -51,5 +51,5 @@ class AddrGenModel(Model):
 
         self.address = self.config["starting_addr"]
         for i in range(self.config["dimensionality"]):
-            offset = self.dim_cnt[i] * self.config[f"stride_{i}"]
+            offset = self.dim_cnt[i] * self.config[f"strides_{i}"]
             self.address = self.address + offset

--- a/lake/models/input_addr_ctrl_model.py
+++ b/lake/models/input_addr_ctrl_model.py
@@ -75,8 +75,8 @@ class InputAddrCtrlModel(Model):
             addr_gen_config["starting_addr"] = self.config[f"address_gen_{i}_starting_addr"]
             addr_gen_config["dimensionality"] = self.config[f"address_gen_{i}_dimensionality"]
             for j in range(self.iterator_support):
-                addr_gen_config[f"stride_{j}"] = self.config[f"address_gen_{i}_strides_{j}"]
-                addr_gen_config[f"range_{j}"] = self.config[f"address_gen_{i}_ranges_{j}"]
+                addr_gen_config[f"strides_{j}"] = self.config[f"address_gen_{i}_strides_{j}"]
+                addr_gen_config[f"ranges_{j}"] = self.config[f"address_gen_{i}_ranges_{j}"]
             self.addr_gens[i].set_config(addr_gen_config)
 
     # Retrieve the current addresses from each generator

--- a/lake/models/output_addr_ctrl_model.py
+++ b/lake/models/output_addr_ctrl_model.py
@@ -72,8 +72,8 @@ class OutputAddrCtrlModel(Model):
             addr_gen_config["starting_addr"] = self.config[f"address_gen_{i}_starting_addr"]
             addr_gen_config["dimensionality"] = self.config[f"address_gen_{i}_dimensionality"]
             for j in range(self.iterator_support):
-                addr_gen_config[f"stride_{j}"] = self.config[f"address_gen_{i}_strides_{j}"]
-                addr_gen_config[f"range_{j}"] = self.config[f"address_gen_{i}_ranges_{j}"]
+                addr_gen_config[f"strides_{j}"] = self.config[f"address_gen_{i}_strides_{j}"]
+                addr_gen_config[f"ranges_{j}"] = self.config[f"address_gen_{i}_ranges_{j}"]
             self.addr_gens[i].set_config(addr_gen_config)
 
     def interact(self, valid_in, step_in):

--- a/tests/test_addr_gen.py
+++ b/tests/test_addr_gen.py
@@ -37,12 +37,12 @@ def test_addr_gen_basic():
 
     tester.circuit.dimensionality = 3
     tester.circuit.starting_addr = 0
-    tester.circuit.stride_0 = 1
-    tester.circuit.stride_1 = 3
-    tester.circuit.stride_2 = 9
-    tester.circuit.range_0 = 3
-    tester.circuit.range_1 = 3
-    tester.circuit.range_2 = 3
+    tester.circuit.strides_0 = 1
+    tester.circuit.strides_1 = 3
+    tester.circuit.strides_2 = 9
+    tester.circuit.ranges_0 = 3
+    tester.circuit.ranges_1 = 3
+    tester.circuit.ranges_2 = 3
 
     tester.circuit.clk = 0
     tester.circuit.clk_en = 1


### PR DESCRIPTION
`addr_gen_model.py` is out of sync with its test. The test sets `strides_{i}` and `ranges_{i}` but the model expects `stride_{i}` and `range_{i}`. This means that when the model is run it only outputs 0 for its address stream. 

This PR fixes that typo, but now the tests will fail because the `AddrGen` module is (probably?) doing the wrong behavior.