### PR TITLE
insert clock enable automatically

### DIFF
--- a/lake/top/lake_top.py
+++ b/lake/top/lake_top.py
@@ -51,7 +51,8 @@ class LakeTop(Generator):
                  config_data_width=16,
                  config_addr_width=8,
                  remove_tb=False,
-                 fifo_mode=True):
+                 fifo_mode=True,
+                 add_clk_enable=True):
         super().__init__("LakeTop", debug=True)
 
         self.data_width = data_width
@@ -943,6 +944,12 @@ class LakeTop(Generator):
         self.add_code(self.transpose_acks)
         self.add_code(self.reduce_acks)
 
+        ########################
+        ##### CLOCK ENABLE #####
+        ########################
+        if add_clk_enable:
+            self.clock_en("clk_en")
+
     @always_comb
     def transpose_acks(self):
         for i in range(self.interconnect_output_ports):
@@ -959,4 +966,5 @@ if __name__ == "__main__":
     lake_dut = LakeTop()
     verilog(lake_dut, filename="lake_top.sv",
             optimize_if=False,
-            additional_passes={"lift config regs": lift_config_reg})
+            additional_passes={"lift config regs": lift_config_reg,
+                               "insert_clock_enable": kts.passes.auto_insert_clock_enable})


### PR DESCRIPTION
I've added a pass in kratos that insert the clock enable automatically:
- Insert clock enable `clk_en` into every module and wire them up to the parent
- If the generator already has a `clk_en` port, use that instead.
- If the generator already has a `clk_en` port and wired to a constant, e.g., 1, `clk_en` will be rewired to the parent port.
- Follow the pattern below in order inside an `always_ff`:
  1. If the `always_ff` only has one if statement block and it is the reset condition
     - if the in the `else` block there is no `clk_en` logic, wrap the entire else block with a new if statement where the condition is `clk_en`
  2. if there are more than one statement or the only if statement is not conditioned on reset or `clk_en`, wrap the entire logic in `always_ff` inside the `clk_en` block.

The code generation follows the standard clock enable style:
- If there is a reset logic:
   ```SystemVerilog
  always_ff  @(...)  begin
        if (!rst_n) begin // or if (rst) or if (~rst_n)
            // ...
        else if (clk_en) begin
            // ...
        end
  end
    ```
- If there no reset logic:
    ```SystemVerilog
  always_ff @(...) begin
        if (clk_en) begin
            // ...
        end
  end
     ````

For now it's disabled by default and only turned on when generate standalone SystemVerilog file. We need to turn it on by default and adjust the test bench files.

Also please double check to make sure the logic insertion is correct in the generated file.