### PR TITLE
Add pass to automatically insert flush (synchronous reset) to top

### DIFF
--- a/lake/passes/passes.py
+++ b/lake/passes/passes.py
@@ -55,11 +55,7 @@ def lift_config_reg(generator):
 #       sram macro and should replace port names accordingly
 #   - sram_macro_info: information about sram macro, including port names to
 #       be replaced
-#   - testing: boolean indicating whether we are generating verilog (in which
-#       case the generator is automatically provided) or whether we are testing
-#       (and need to specify the generator explicitly)
-#   - generator: explicit specification of generator if needed
-def change_sram_port_names(use_sram_stub, sram_macro_info, testing, generator):
+def change_sram_port_names(use_sram_stub, sram_macro_info):
 
     def change_sram_port_names_wrapper(generator):
 
@@ -94,7 +90,4 @@ def change_sram_port_names(use_sram_stub, sram_macro_info, testing, generator):
         v = SRAMPortNames(use_sram_stub, sram_macro_info)
         v.visit_root(generator)
 
-    if testing:
-        return change_sram_port_names_wrapper(generator)
-    else:
-        return change_sram_port_names_wrapper
+    return change_sram_port_names_wrapper

--- a/lake/top/lake_top.py
+++ b/lake/top/lake_top.py
@@ -48,7 +48,8 @@ class LakeTop(Generator):
                  config_addr_width=8,
                  remove_tb=False,
                  fifo_mode=True,
-                 add_clk_enable=False):
+                 add_clk_enable=False,
+                 add_flush=False):
         super().__init__("LakeTop", debug=True)
 
         self.data_width = data_width
@@ -674,25 +675,25 @@ class LakeTop(Generator):
         if add_clk_enable:
             self.clock_en("clk_en")
 
+        if add_flush:
+            self.add_attribute("sync-reset=flush")
+
 
 if __name__ == "__main__":
     tsmc_info = SRAMMacroInfo("tsmc_name")
-    use_sram_stub = 1
+    use_sram_stub = True
     fifo_mode = True
     mem_width = 64
     lake_dut = LakeTop(mem_width=mem_width,
                        sram_macro_info=tsmc_info,
                        use_sram_stub=use_sram_stub,
-                       fifo_mode=fifo_mode)
+                       fifo_mode=fifo_mode,
+                       add_clk_enable=True,
+                       add_flush=True)
+    sram_port_pass = change_sram_port_names(use_sram_stub=True, sram_macro_info=tsmc_info)
     verilog(lake_dut, filename="lake_top.sv",
             optimize_if=False,
             additional_passes={"lift config regs": lift_config_reg,
-                               "change sram port names": change_sram_port_names(
-                                   use_sram_stub,
-                                   tsmc_info,
-                                   0,
-                                   0)})
-    # verilog(lake_dut, filename="lake_top.sv",
-    #         optimize_if=False,
-    #         additional_passes={"lift config regs": lift_config_reg,
-    #                            "insert_clock_enable": kts.passes.auto_insert_clock_enable})
+                               "change sram port names": sram_port_pass,
+                               "insert_clock_enable": kts.passes.auto_insert_clock_enable,
+                               "insert_flush": kts.passes.auto_insert_sync_reset})

--- a/tests/test_top.py
+++ b/tests/test_top.py
@@ -81,16 +81,14 @@ def test_sram_port_names_change(mem_width,
     # Run the config reg lift
     lift_config_reg(lt_dut.internal_generator)
 
-    change_sram_port_names(use_sram_stub,
-                           sram_macro_info,
-                           1,
-                           lt_dut.internal_generator)
+    change_sram_port_pass = change_sram_port_names(use_sram_stub, sram_macro_info)
 
     magma_dut = kts.util.to_magma(lt_dut,
                                   flatten_array=True,
                                   check_multiple_driver=False,
                                   optimize_if=False,
-                                  check_flip_flop_always_ff=False)
+                                  check_flip_flop_always_ff=False,
+                                  additional_passes={"change_sran_port": change_sram_port_pass})
 
 
 def test_identity_stream(data_width=16,

--- a/tests/test_top.py
+++ b/tests/test_top.py
@@ -88,7 +88,7 @@ def test_sram_port_names_change(mem_width,
                                   check_multiple_driver=False,
                                   optimize_if=False,
                                   check_flip_flop_always_ff=False,
-                                  additional_passes={"change_sran_port": change_sram_port_pass})
+                                  additional_passes={"change_sram_port": change_sram_port_pass})
 
 
 def test_identity_stream(data_width=16,


### PR DESCRIPTION
The reset logic is generated based on the following pattern:
- If the generator already has a synchronous reset, skip it
- If the generator's synchronous reset is wired to a constant, remove it and wire it to it's parent
- If the `always_ff` has async reset logc, duplicated the async logic inside the sync reset `if` clause.
- Clock enable has higher priority than synchronous reset. This priority, however, can be adjusted through generator attribute since the pass supports both.

Some other minor fixes in the PR:
1. Refactor the SRAM renaming pass (making it more Pythonic, instead of C style).
2. Resurrect the clock enable pass.

TODO:
I will enable the clock enable and flush by default in top, and then fix the top level tests.