### PR TITLE
Fix for pond integration

### DIFF
--- a/lake/top/lake_top.py
+++ b/lake/top/lake_top.py
@@ -55,8 +55,9 @@ class LakeTop(Generator):
                  fifo_mode=True,
                  add_clk_enable=True,
                  add_flush=True,
-                 stcl_valid_iter=4):
-        super().__init__("LakeTop", debug=True)
+                 stcl_valid_iter=4,
+                 name="LakeTop"):
+        super().__init__(name, debug=True)
 
         self.data_width = data_width
         self.mem_width = mem_width

--- a/lake/utils/sram_macro.py
+++ b/lake/utils/sram_macro.py
@@ -33,3 +33,9 @@ class SRAMMacroInfo:
                       wen_port_name,
                       wtsel_port_name,
                       rtsel_port_name)
+
+    def __hash__(self):
+        return hash(self.ports)
+
+    def __eq__(self, other: "SRAMMacroInfo"):
+        return self.ports == other.ports


### PR DESCRIPTION
1. allow generator name override in lake top. magma can't rename two verilog circuit if both of them have the same name, i.e. `LakeTop`.
2. fix gemstone caching. Previously the instance address is used as cache index.