### PR TITLE
Simplify Chaining with Accessor Scheme

### DIFF
--- a/lake/modules/chain_accessor.py
+++ b/lake/modules/chain_accessor.py
@@ -1,0 +1,51 @@
+from kratos import *
+import kratos as kts
+
+
+class ChainAccessor(Generator):
+    def __init__(self,
+                 data_width,
+                 interconnect_output_ports):
+        super().__init__("Chain", debug=True)
+
+        # generator parameters
+        self.data_width = data_width
+        self.interconnect_output_ports = interconnect_output_ports
+
+        # inputs
+        self._curr_tile_data_out = self.input("curr_tile_data_out",
+                                              self.data_width,
+                                              size=self.interconnect_output_ports,
+                                              packed=True,
+                                              explicit_array=True)
+
+        self._chain_data_in = self.input("chain_data_in",
+                                         self.data_width,
+                                         size=self.interconnect_output_ports,
+                                         packed=True,
+                                         explicit_array=True)
+
+        self._accessor_output = self.input("accessor_output",
+                                           self.interconnect_output_ports)
+
+        self._data_out_tile = self.output("data_out_tile",
+                                          self.data_width,
+                                          size=self.interconnect_output_ports,
+                                          packed=True,
+                                          explicit_array=True)
+
+        self.add_code(self.set_data_out)
+
+    @always_comb
+    def set_data_out(self):
+        for i in range(self.interconnect_output_ports):
+            if self._accessor_output[i]:
+                self._data_out_tile[i] = self._curr_tile_data_out[i]
+            else:
+                self._data_out_tile[i] = self._chain_data_in[i]
+
+
+if __name__ == "__main__":
+    dut = ChainAccessor(data_width=16,
+                        interconnect_output_ports=2)
+    verilog(dut, filename="chain_acc.sv")

--- a/lake/modules/sram.py
+++ b/lake/modules/sram.py
@@ -178,7 +178,7 @@ class SRAM(Generator):
             self._mem_addr_to_sram = self._mem_addr_in_bank
         else:
             self._mem_addr_to_sram = self._mem_addr_in_bank[self.address_width - self.chain_idx_bits - 1, 0]
-    
+
 
 if __name__ == "__main__":
     dut = SRAM(use_sram_stub=0,

--- a/lake/modules/sram.py
+++ b/lake/modules/sram.py
@@ -1,0 +1,194 @@
+from kratos import *
+from math import log
+from lake.modules.sram_stub import SRAMStub
+from lake.modules.sram_stub_generator import SRAMStubGenerator
+from lake.utils.flattenND import FlattenND
+from lake.utils.reverse_flatten import ReverseFlatten
+
+
+class SRAM(Generator):
+
+    def __init__(self,
+                 use_sram_stub,
+                 sram_name,
+                 data_width,
+                 fw_int,
+                 mem_depth,
+                 mem_input_ports,
+                 mem_output_ports,
+                 address_width,
+                 bank_num,
+                 num_tiles):
+        super().__init__(f"{sram_name}_generator")
+
+        self.use_sram_stub = use_sram_stub
+        self.sram_name = sram_name
+        self.data_width = data_width
+        self.fw_int = fw_int
+        self.mem_depth = mem_depth
+        self.mem_input_ports = mem_input_ports
+        self.mem_output_ports = mem_output_ports
+        self.address_width = address_width
+        self.bank_num = bank_num
+        self.num_tiles = num_tiles
+
+        self.chain_idx_bits = max(1, clog2(num_tiles))
+
+        self._gclk = self.clock("clk")
+
+        self._clk_en = self.input("clk_en", 1)
+
+        if self.fw_int > 1:
+            self._mem_data_in_bank = self.input("mem_data_in_bank",
+                                                self.data_width,
+                                                size=self.fw_int,
+                                                packed=True,
+                                                explicit_array=True)
+
+            self._mem_data_out_bank = self.output("mem_data_out_bank",
+                                                  self.data_width,
+                                                  size=(self.mem_output_ports,
+                                                        self.fw_int),
+                                                  packed=True,
+                                                  explicit_array=True)
+
+            if not self.use_sram_stub:
+                # flattened version of input data
+                self._sram_mem_data_in_bank = self.var("sram_mem_data_in_bank",
+                                                       self.data_width *
+                                                       self.fw_int *
+                                                       self.mem_input_ports)
+
+                # flattened version of output data
+                self._sram_mem_data_out_bank = self.var("sram_mem_data_out_bank",
+                                                        self.data_width *
+                                                        self.fw_int *
+                                                        self.mem_output_ports)
+        else:
+            self._mem_data_in_bank = self.input("mem_data_in_bank", self.data_width, packed=True)
+
+            self._mem_data_out_bank = self.output("mem_data_out_bank", self.data_width, packed=True)
+
+        self._mem_addr_in_bank = self.input("mem_addr_in_bank",
+                                            self.address_width)
+        if num_tiles == 1:
+            self._mem_addr_to_sram = self.var("mem_addr_to_sram",
+                                              self.address_width)
+        else:
+            self._mem_addr_to_sram = self.var("mem_addr_to_sram",
+                                              self.address_width - self.chain_idx_bits)
+
+        self._mem_cen_in_bank = self.input("mem_cen_in_bank", self.mem_output_ports)
+
+        self._mem_wen_in_bank = self.input("mem_wen_in_bank", self.mem_input_ports)
+
+        self._wtsel = self.input("wtsel", 2)
+        self._rtsel = self.input("rtsel", 2)
+
+        if self.use_sram_stub:
+            mbank = SRAMStub(data_width=self.data_width,
+                             width_mult=self.fw_int,
+                             depth=self.mem_depth)
+
+            self.add_child(f"mem_{self.bank_num}", mbank,
+                           clk=self._gclk,
+                           data_in=self._mem_data_in_bank,
+                           addr=self._mem_addr_to_sram,
+                           cen=self._mem_cen_in_bank,
+                           wen=self._mem_wen_in_bank,
+                           data_out=self._mem_data_out_bank)
+
+        # instantiante external provided sram macro and flatten input/output data
+        # if fetch width is greater than 1
+        else:
+            mbank = SRAMStubGenerator(sram_name=self.sram_name,
+                                      data_width=self.data_width,
+                                      width_mult=self.fw_int,
+                                      depth=self.mem_depth)
+
+            compose_wide = True
+
+            if self.fw_int > 1:
+                flatten_data_in = FlattenND(self.data_width,
+                                            self.fw_int,
+                                            self.mem_input_ports)
+
+                self.add_child(f"flatten_data_in_{self.bank_num}",
+                               flatten_data_in,
+                               input_array=self._mem_data_in_bank,
+                               output_array=self._sram_mem_data_in_bank)
+
+                if compose_wide:
+                    for j in range(2):
+                        mbank = SRAMStubGenerator(sram_name=self.sram_name,
+                                                  data_width=self.data_width,
+                                                  width_mult=self.fw_int // 2,
+                                                  depth=self.mem_depth)
+
+                        self.add_child(f"mem_inst_{self.bank_num}_pt_{j}",
+                                       mbank,
+                                       sram_addr=self._mem_addr_to_sram,
+                                       sram_cen=~self._mem_cen_in_bank,
+                                       sram_clk=self._gclk,
+                                       sram_data_in=self._sram_mem_data_in_bank[j * 32 + 32 - 1, j * 32],
+                                       sram_data_out=self._sram_mem_data_out_bank[j * 32 + 32 - 1, j * 32],
+                                       sram_wen=~self._mem_wen_in_bank,
+                                       sram_wtsel=self._wtsel,
+                                       sram_rtsel=self._rtsel)
+
+                else:
+                    self.add_child(f"mem_inst_{self.bank_num}",
+                                   mbank,
+                                   sram_addr=self._mem_addr_to_sram,
+                                   sram_cen=~self._mem_cen_in_bank,
+                                   sram_clk=self._gclk,
+                                   sram_data_in=self._sram_mem_data_in_bank,
+                                   sram_data_out=self._sram_mem_data_out_bank,
+                                   sram_wen=~self._mem_wen_in_bank,
+                                   sram_wtsel=self._wtsel,
+                                   sram_rtsel=self._rtsel)
+
+                flatten_data_out = ReverseFlatten(self.data_width,
+                                                  self.fw_int,
+                                                  self.mem_output_ports)
+
+                self.add_child(f"flatten_data_out_{self.bank_num}",
+                               flatten_data_out,
+                               input_array=self._sram_mem_data_out_bank,
+                               output_array=self._mem_data_out_bank)
+
+            else:
+                self.add_child(f"mem_inst_{self.bank_num}",
+                               mbank,
+                               sram_addr=self._mem_addr_to_sram,
+                               sram_cen=~self._mem_cen_in_bank,
+                               sram_clk=self._gclk,
+                               sram_data_in=self._mem_data_in_bank,
+                               sram_data_out=self._mem_data_out_bank,
+                               sram_wen=~self._mem_wen_in_bank,
+                               sram_wtsel=self._wtsel,
+                               sram_rtsel=self._rtsel)
+
+        self.add_code(self.set_mem_addr)
+
+    @always_comb
+    def set_mem_addr(self):
+        # these ranges are inclusive
+        if num_tiles == 1:
+            self._mem_addr_to_sram = self._mem_addr_in_bank
+        else:
+            self._mem_addr_to_sram = self._mem_addr_in_bank[self.address_width - self.chain_idx_bits - 1, 0]
+    
+
+if __name__ == "__main__":
+    dut = SRAM(use_sram_stub=0,
+               sram_name="TSMC",
+               data_width=16,
+               fw_int=4,
+               mem_depth=128,
+               mem_input_ports=1,
+               mem_output_ports=1,
+               address_width=7,
+               bank_num=4,
+               num_tiles=1)
+    verilog(dut, filename="wrapper.sv")

--- a/lake/modules/strg_ub_thin.py
+++ b/lake/modules/strg_ub_thin.py
@@ -96,7 +96,10 @@ class StrgUBThin(Generator):
 
         # local variables
         self._write = self.var("write", 1)
-        self._read = self.var("read", 1)
+        self._read = self.var("read", self.interconnect_output_ports)
+        self._accessor_output = self.output("accessor_output", self.interconnect_output_ports)
+        self.wire(self._accessor_output, self._read)
+
         self._valid_out = self.output("valid_out", 1)
         if self.read_delay == 1:
             self._read_d1 = self.var("read_d1", 1)

--- a/lake/modules/strg_ub_vec.py
+++ b/lake/modules/strg_ub_vec.py
@@ -275,6 +275,10 @@ class StrgUBVec(Generator):
                        valid_output=self._read)
 
         self._tb_read = self.var("tb_read", self.interconnect_output_ports)
+        self._accessor_output = self.output("accessor_output", self.interconnect_output_ports)
+
+        self.wire(self._accessor_output, self._tb_read)
+
         self.tb_height = 4
 
         self._tb_write_addr = self.var("tb_write_addr", 6,

--- a/lake/top/lake_top.py
+++ b/lake/top/lake_top.py
@@ -1,6 +1,6 @@
 from kratos import *
 from lake.modules.passthru import *
-from lake.modules.sram_wrapper import SRAMWrapper
+from lake.modules.sram import SRAM
 from lake.modules.strg_ub_vec import StrgUBVec
 from lake.modules.strg_ub_thin import StrgUBThin
 from lake.modules.storage_config_seq import StorageConfigSeq
@@ -18,32 +18,32 @@ import kratos as kts
 class LakeTop(Generator):
     def __init__(self,
                  data_width=16,  # CGRA Params
-                 mem_width=16,
+                 mem_width=64,
                  mem_depth=256,
                  banks=1,
                  input_iterator_support=6,  # Addr Controllers
                  output_iterator_support=6,
                  input_config_width=16,
                  output_config_width=16,
-                 interconnect_input_ports=2,  # Connection to int
-                 interconnect_output_ports=2,
+                 interconnect_input_ports=1,  # Connection to int
+                 interconnect_output_ports=1,
                  mem_input_ports=1,
                  mem_output_ports=1,
                  use_sram_stub=True,
                  sram_macro_info=SRAMMacroInfo(),
                  read_delay=1,  # Cycle delay in read (SRAM vs Register File)
-                 rw_same_cycle=True,  # Does the memory allow r+w in same cycle?
+                 rw_same_cycle=False,  # Does the memory allow r+w in same cycle?
                  agg_height=4,
                  tb_sched_max=16,
                  config_data_width=32,
                  config_addr_width=8,
                  num_tiles=1,
                  remove_tb=False,
-                 fifo_mode=False,
+                 fifo_mode=True,
                  add_clk_enable=True,
                  add_flush=True,
                  name="LakeTop",
-                 gen_addr=False):
+                 gen_addr=True):
         super().__init__(name, debug=True)
 
         self.data_width = data_width
@@ -79,7 +79,6 @@ class LakeTop(Generator):
         self.sets_per_macro = max(1, int(self.mem_depth / self.data_words_per_set))
         self.total_sets = max(1, self.banks * self.sets_per_macro)
 
-        self.chain_idx_bits = max(1, clog2(num_tiles))
         # phases = [] TODO
 
         # CLK and RST
@@ -113,12 +112,12 @@ class LakeTop(Generator):
                                          explicit_array=True)
         self._chain_data_in.add_attribute(ControlSignalAttr(False))
 
-        self._chain_data_out = self.output("chain_data_out",
-                                           self.data_width,
-                                           size=self.interconnect_output_ports,
-                                           packed=True,
-                                           explicit_array=True)
-        self._chain_data_out.add_attribute(ControlSignalAttr(False))
+        # self._chain_data_out = self.output("chain_data_out",
+        #                                    self.data_width,
+        #                                    size=self.interconnect_output_ports,
+        #                                    packed=True,
+        #                                    explicit_array=True)
+        # self._chain_data_out.add_attribute(ControlSignalAttr(False))
 
         # self._chain_valid_out = self.output("chain_valid_out",
         #                                     self.interconnect_output_ports)
@@ -207,9 +206,9 @@ class LakeTop(Generator):
                                      explicit_array=True)
         self._data_out.add_attribute(ControlSignalAttr(False))
 
-        self._valid_out = self.output("valid_out",
-                                      self.interconnect_output_ports)
-        self._valid_out.add_attribute(ControlSignalAttr(False))
+        # self._valid_out = self.output("valid_out",
+        #                               self.interconnect_output_ports)
+        # self._valid_out.add_attribute(ControlSignalAttr(False))
 
         self._data_out_tile = self.var("data_out_tile",
                                        self.data_width,
@@ -333,11 +332,6 @@ class LakeTop(Generator):
                                     size=self.banks,
                                     explicit_array=True,
                                     packed=True)
-
-        self._mem_valid_data = self.var("mem_valid_data", self.mem_output_ports,
-                                        size=self.banks,
-                                        explicit_array=True,
-                                        packed=True)
 
         self._mem_wen_in = self.var("mem_wen_in", self.mem_input_ports,
                                     size=self.banks,
@@ -534,7 +528,7 @@ class LakeTop(Generator):
                        data_out=self._ub_data_out,
                        #    valid_out=self._ub_valid_out,
                        data_to_strg=self._ub_data_to_mem,
-                       ren_to_strg=self._ub_cen_to_mem,
+                       cen_to_strg=self._ub_cen_to_mem,
                        wen_to_strg=self._ub_wen_to_mem,
                        accessor_output=self._accessor_output)
 
@@ -702,23 +696,19 @@ class LakeTop(Generator):
             self.wire(self._mem_addr_dp, self._all_addr_to_mem[self._mode])
 
             for i in range(self.banks):
-                mbank = SRAMWrapper(use_sram_stub=self.use_sram_stub,
-                                    sram_name=self.sram_macro_info.name,
-                                    data_width=self.data_width,
-                                    fw_int=self.fw_int,
-                                    mem_depth=self.mem_depth,
-                                    mem_input_ports=self.mem_input_ports,
-                                    mem_output_ports=self.mem_output_ports,
-                                    address_width=self.address_width,
-                                    bank_num=i,
-                                    num_tiles=self.num_tiles)
+                mbank = SRAM(use_sram_stub=self.use_sram_stub,
+                             sram_name=self.sram_macro_info.name,
+                             data_width=self.data_width,
+                             fw_int=self.fw_int,
+                             mem_depth=self.mem_depth,
+                             mem_input_ports=self.mem_input_ports,
+                             mem_output_ports=self.mem_output_ports,
+                             address_width=self.address_width,
+                             bank_num=i,
+                             num_tiles=self.num_tiles)
 
                 self.add_child(f"mem_{i}", mbank,
                                clk=self._gclk,
-                               enable_chain_input=self._enable_chain_input,
-                               enable_chain_output=self._enable_chain_output,
-                               chain_idx_input=self._chain_idx_input,
-                               chain_idx_output=self._chain_idx_output,
                                clk_en=self._clk_en | self._config_en.r_or(),
                                mem_data_in_bank=self._mem_data_in[i],
                                mem_data_out_bank=self._mem_data_out[i],
@@ -726,8 +716,7 @@ class LakeTop(Generator):
                                mem_cen_in_bank=self._mem_cen_in[i],
                                mem_wen_in_bank=self._mem_wen_in[i],
                                wtsel=self.sram_macro_info.wtsel_value,
-                               rtsel=self.sram_macro_info.rtsel_value,
-                               valid_data=self._mem_valid_data[i])
+                               rtsel=self.sram_macro_info.rtsel_value)
         else:
 
             self.wire(self._mem_data_dp, self._ub_data_to_mem)
@@ -825,8 +814,8 @@ class LakeTop(Generator):
 if __name__ == "__main__":
     tsmc_info = SRAMMacroInfo("tsmc_name")
     use_sram_stub = True
-    fifo_mode = False
-    mem_width = 16
+    fifo_mode = True
+    mem_width =64 
     lake_dut = LakeTop(mem_width=mem_width,
                        sram_macro_info=tsmc_info,
                        use_sram_stub=use_sram_stub,

--- a/lake/top/lake_top.py
+++ b/lake/top/lake_top.py
@@ -815,7 +815,7 @@ if __name__ == "__main__":
     tsmc_info = SRAMMacroInfo("tsmc_name")
     use_sram_stub = True
     fifo_mode = True
-    mem_width =64 
+    mem_width = 64
     lake_dut = LakeTop(mem_width=mem_width,
                        sram_macro_info=tsmc_info,
                        use_sram_stub=use_sram_stub,


### PR DESCRIPTION
- chaining module now looks at output accessor enable (added as output to strg_ub modules) and determines whether to take current tile's data or chain_data_in
- no chaining config regs, no chain_data_out and data just goes to data_out (talked to Joey)
- remove chaining logic from SRAMWrapper (talked to Joey about how accessor/addressor can be used to input data before agg, no need for us to have this control anymore)

Also, LakeTop params were changed for testing, but I can revert those if we need.