### PR TITLE
New/diet pond

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,10 @@
 # SWAP #
 ########
 *.swp
+.magma/
+*.txt
+*.csv
+*.json
 
 ###############
 # Build Files #

--- a/lake/modules/addr_gen.py
+++ b/lake/modules/addr_gen.py
@@ -20,10 +20,10 @@ class AddrGen(Generator):
         self.iterator_support = iterator_support
         self.config_width = config_width
         # Create params for instancing this module...
-        self.iterator_support_par = self.param("ITERATOR_SUPPORT", clog2(iterator_support) + 1,
-                                               initial_value=self.iterator_support)
-        self.config_width_par = self.param("CONFIG_WIDTH", clog2(config_width) + 1,
-                                           initial_value=self.config_width)
+        # self.iterator_support_par = self.param("ITERATOR_SUPPORT", clog2(iterator_support) + 1,
+        #                                        initial_value=self.iterator_support)
+        # self.config_width_par = self.param("CONFIG_WIDTH", clog2(config_width) + 1,
+        #                                    initial_value=self.config_width)
 
         # PORT DEFS: begin
 
@@ -33,13 +33,13 @@ class AddrGen(Generator):
 
         self._restart = self.input("restart", 1)
 
-        self._strides = self.input("strides", self.config_width_par,
-                                   size=self.iterator_support_par,
+        self._strides = self.input("strides", self.config_width,
+                                   size=self.iterator_support,
                                    packed=True, explicit_array=True)
         self._strides.add_attribute(ConfigRegAttr("Strides of address generator"))
         self._strides.add_attribute(FormalAttr(f"{self._strides.name}", FormalSignalConstraint.SOLVE))
 
-        self._starting_addr = self.input("starting_addr", self.config_width_par)
+        self._starting_addr = self.input("starting_addr", self.config_width)
         self._starting_addr.add_attribute(ConfigRegAttr("Starting address of address generator"))
         self._starting_addr.add_attribute(FormalAttr(f"{self._starting_addr.name}", FormalSignalConstraint.SOLVE))
 
@@ -47,24 +47,24 @@ class AddrGen(Generator):
 
         # OUTPUTS
         # TODO why is this config width instead of address width?
-        self._addr_out = self.output("addr_out", self.config_width_par)
+        self._addr_out = self.output("addr_out", self.config_width)
 
         # PORT DEFS: end
 
         # LOCAL VARIABLES: begin
-        self._strt_addr = self.var("strt_addr", self.config_width_par)
+        self._strt_addr = self.var("strt_addr", self.config_width)
 
-        self._calc_addr = self.var("calc_addr", self.config_width_par)
+        self._calc_addr = self.var("calc_addr", self.config_width)
 
-        self._max_value = self.var("max_value", self.iterator_support_par)
+        self._max_value = self.var("max_value", self.iterator_support)
 
         # LOCAL VARIABLES: end
         # GENERATION LOGIC: begin
         self.wire(self._strt_addr, self._starting_addr)
         self.wire(self._addr_out, self._calc_addr)
-        self._mux_sel = self.input("mux_sel", clog2(self.iterator_support_par))
+        self._mux_sel = self.input("mux_sel", max(clog2(self.iterator_support), 1))
 
-        self._current_addr = self.var("current_addr", self.config_width_par)
+        self._current_addr = self.var("current_addr", self.config_width)
         # Calculate address by taking previous calculation and adding the muxed stride
         self.wire(self._calc_addr, self._strt_addr + self._current_addr)
 

--- a/lake/modules/addr_gen.py
+++ b/lake/modules/addr_gen.py
@@ -15,6 +15,8 @@ class AddrGen(Generator):
 
         super().__init__(f"addr_gen", debug=True)
 
+        assert iterator_support > 1, f"Hardware only supports an iterator support of 2 or more: you tried {iterator_support}"
+
         self.iterator_support = iterator_support
         self.config_width = config_width
         # Create params for instancing this module...
@@ -60,7 +62,7 @@ class AddrGen(Generator):
         # GENERATION LOGIC: begin
         self.wire(self._strt_addr, self._starting_addr)
         self.wire(self._addr_out, self._calc_addr)
-        self._mux_sel = self.input("mux_sel", max(clog2(self.iterator_support), 1))
+        self._mux_sel = self.input("mux_sel", clog2(self.iterator_support_par))
 
         self._current_addr = self.var("current_addr", self.config_width_par)
         # Calculate address by taking previous calculation and adding the muxed stride

--- a/lake/modules/addr_gen.py
+++ b/lake/modules/addr_gen.py
@@ -13,7 +13,7 @@ class AddrGen(Generator):
                  iterator_support=6,
                  config_width=16):
 
-        super().__init__(f"addr_gen", debug=True)
+        super().__init__(f"addr_gen_{iterator_support}_{config_width}", debug=True)
 
         assert iterator_support > 1, f"Hardware only supports an iterator support of 2 or more: you tried {iterator_support}"
 

--- a/lake/modules/addr_gen.py
+++ b/lake/modules/addr_gen.py
@@ -18,8 +18,10 @@ class AddrGen(Generator):
         self.iterator_support = iterator_support
         self.config_width = config_width
         # Create params for instancing this module...
-        self.iterator_support_par = self.param("ITERATOR_SUPPORT", clog2(iterator_support) + 1, value=self.iterator_support)
-        self.config_width_par = self.param("CONFIG_WIDTH", clog2(config_width) + 1, value=self.config_width)
+        self.iterator_support_par = self.param("ITERATOR_SUPPORT", clog2(iterator_support) + 1,
+                                               initial_value=self.iterator_support)
+        self.config_width_par = self.param("CONFIG_WIDTH", clog2(config_width) + 1,
+                                           initial_value=self.config_width)
 
         # PORT DEFS: begin
 
@@ -29,13 +31,13 @@ class AddrGen(Generator):
 
         self._restart = self.input("restart", 1)
 
-        self._strides = self.input("strides", self.config_width,
-                                   size=self.iterator_support,
+        self._strides = self.input("strides", self.config_width_par,
+                                   size=self.iterator_support_par,
                                    packed=True, explicit_array=True)
         self._strides.add_attribute(ConfigRegAttr("Strides of address generator"))
         self._strides.add_attribute(FormalAttr(f"{self._strides.name}", FormalSignalConstraint.SOLVE))
 
-        self._starting_addr = self.input("starting_addr", self.config_width)
+        self._starting_addr = self.input("starting_addr", self.config_width_par)
         self._starting_addr.add_attribute(ConfigRegAttr("Starting address of address generator"))
         self._starting_addr.add_attribute(FormalAttr(f"{self._starting_addr.name}", FormalSignalConstraint.SOLVE))
 
@@ -43,16 +45,16 @@ class AddrGen(Generator):
 
         # OUTPUTS
         # TODO why is this config width instead of address width?
-        self._addr_out = self.output("addr_out", self.config_width)
+        self._addr_out = self.output("addr_out", self.config_width_par)
 
         # PORT DEFS: end
 
         # LOCAL VARIABLES: begin
-        self._strt_addr = self.var("strt_addr", self.config_width)
+        self._strt_addr = self.var("strt_addr", self.config_width_par)
 
-        self._calc_addr = self.var("calc_addr", self.config_width)
+        self._calc_addr = self.var("calc_addr", self.config_width_par)
 
-        self._max_value = self.var("max_value", self.iterator_support)
+        self._max_value = self.var("max_value", self.iterator_support_par)
 
         # LOCAL VARIABLES: end
         # GENERATION LOGIC: begin
@@ -60,7 +62,7 @@ class AddrGen(Generator):
         self.wire(self._addr_out, self._calc_addr)
         self._mux_sel = self.input("mux_sel", max(clog2(self.iterator_support), 1))
 
-        self._current_addr = self.var("current_addr", self.config_width)
+        self._current_addr = self.var("current_addr", self.config_width_par)
         # Calculate address by taking previous calculation and adding the muxed stride
         self.wire(self._calc_addr, self._strt_addr + self._current_addr)
 

--- a/lake/modules/for_loop.py
+++ b/lake/modules/for_loop.py
@@ -13,7 +13,7 @@ class ForLoop(Generator):
                  iterator_support=6,
                  config_width=16):
 
-        super().__init__(f"for_loop", debug=True)
+        super().__init__(f"for_loop_{iterator_support}_{config_width}", debug=True)
 
         self.iterator_support = iterator_support
         self.config_width = config_width

--- a/lake/modules/register_file.py
+++ b/lake/modules/register_file.py
@@ -28,7 +28,7 @@ class RegisterFile(Generator):
         # Clock and Reset          #
         ############################
         self._clk = self.clock("clk")
-        self._rst_n = self.reset("rst_n")
+        # self._rst_n = self.reset("rst_n")
 
         ############################
         # Inputs                   #
@@ -105,19 +105,15 @@ class RegisterFile(Generator):
     ##########################
     # Access sram array      #
     ##########################
-    @always_ff((posedge, "clk"), (negedge, "rst_n"))
+    @always_ff((posedge, "clk"))
     def seq_data_access(self):
         for i in range(self.write_ports):
-            if ~self._rst_n:
-                self._data_array = 0
-            elif self._wen[i]:
+            if self._wen[i]:
                 self._data_array[self._wr_addr[i]] = self._data_in[i]
 
-    @always_ff((posedge, "clk"), (negedge, "rst_n"))
+    @always_ff((posedge, "clk"))
     def seq_data_access_one_w(self):
-        if ~self._rst_n:
-            self._data_array = 0
-        elif self._wen:
+        if self._wen:
             self._data_array[self._wr_addr] = self._data_in
 
     @always_comb
@@ -129,19 +125,15 @@ class RegisterFile(Generator):
     def comb_data_out_one_r(self):
         self._data_out = self._data_array[self._rd_addr]
 
-    @always_ff((posedge, "clk"), (negedge, "rst_n"))
+    @always_ff((posedge, "clk"))
     def seq_data_out(self):
         for i in range(self.read_ports):
-            if ~self._rst_n:
-                self._data_out[i] = 0
-            elif self._ren:
+            if self._ren:
                 self._data_out[i] = self._data_array[self._rd_addr[i]]
 
-    @always_ff((posedge, "clk"), (negedge, "rst_n"))
+    @always_ff((posedge, "clk"))
     def seq_data_out_one_r(self):
-        if ~self._rst_n:
-            self._data_out = 0
-        elif self._ren:
+        if self._ren:
             self._data_out = self._data_array[self._rd_addr]
 
 

--- a/lake/modules/spec/sched_gen.py
+++ b/lake/modules/spec/sched_gen.py
@@ -14,7 +14,7 @@ class SchedGen(Generator):
                  iterator_support=6,
                  config_width=16):
 
-        super().__init__(f"sched_gen")
+        super().__init__(f"sched_gen_{iterator_support}_{config_width}")
 
         self.iterator_support = iterator_support
         self.config_width = config_width

--- a/lake/modules/spec/sched_gen.py
+++ b/lake/modules/spec/sched_gen.py
@@ -19,8 +19,8 @@ class SchedGen(Generator):
         self.iterator_support = iterator_support
         self.config_width = config_width
         # Create params for instancing this module...
-        self.iterator_support_par = self.param("ITERATOR_SUPPORT", clog2(iterator_support) + 1, value=self.iterator_support)
-        self.config_width_par = self.param("CONFIG_WIDTH", clog2(config_width) + 1, value=self.config_width)
+        self.iterator_support_par = self.param("ITERATOR_SUPPORT", clog2(iterator_support) + 1, initial_value=self.iterator_support)
+        self.config_width_par = self.param("CONFIG_WIDTH", clog2(config_width) + 1, initial_value=self.config_width)
         # PORT DEFS: begin
 
         # INPUTS
@@ -43,7 +43,9 @@ class SchedGen(Generator):
         # PORT DEFS: end
 
         self.add_child(f"sched_addr_gen",
-                       AddrGen(),
+                       AddrGen(iterator_support=self.iterator_support,
+                               config_width=self.config_width),
+
                        clk=self._clk,
                        rst_n=self._rst_n,
                        step=self._valid_out,

--- a/lake/modules/spec/sched_gen.py
+++ b/lake/modules/spec/sched_gen.py
@@ -43,15 +43,15 @@ class SchedGen(Generator):
         # PORT DEFS: end
 
         self.add_child(f"sched_addr_gen",
-                       AddrGen(iterator_support=self.iterator_support,
-                               config_width=self.config_width),
-
+                       AddrGen(),
                        clk=self._clk,
                        rst_n=self._rst_n,
                        step=self._valid_out,
                        mux_sel=self._mux_sel,
                        addr_out=self._addr_out,
-                       restart=const(0, 1))
+                       restart=const(0, 1),
+                       CONFIG_WIDTH=self.config_width_par,
+                       ITERATOR_SUPPORT=self.iterator_support_par)
 
         self.add_code(self.set_valid_out)
         self.add_code(self.set_valid_output)

--- a/lake/modules/spec/sched_gen.py
+++ b/lake/modules/spec/sched_gen.py
@@ -19,8 +19,8 @@ class SchedGen(Generator):
         self.iterator_support = iterator_support
         self.config_width = config_width
         # Create params for instancing this module...
-        self.iterator_support_par = self.param("ITERATOR_SUPPORT", clog2(iterator_support) + 1, initial_value=self.iterator_support)
-        self.config_width_par = self.param("CONFIG_WIDTH", clog2(config_width) + 1, initial_value=self.config_width)
+        # self.iterator_support_par = self.param("ITERATOR_SUPPORT", clog2(iterator_support) + 1, initial_value=self.iterator_support)
+        # self.config_width_par = self.param("CONFIG_WIDTH", clog2(config_width) + 1, initial_value=self.config_width)
         # PORT DEFS: begin
 
         # INPUTS
@@ -51,9 +51,7 @@ class SchedGen(Generator):
                        step=self._valid_out,
                        mux_sel=self._mux_sel,
                        addr_out=self._addr_out,
-                       restart=const(0, 1),
-                       CONFIG_WIDTH=self.config_width_par,
-                       ITERATOR_SUPPORT=self.iterator_support_par)
+                       restart=const(0, 1))
 
         self.add_code(self.set_valid_out)
         self.add_code(self.set_valid_output)

--- a/lake/modules/spec/sched_gen.py
+++ b/lake/modules/spec/sched_gen.py
@@ -12,14 +12,12 @@ class SchedGen(Generator):
     '''
     def __init__(self,
                  iterator_support=6,
-                 config_width=16,
-                 glbl_cyc_width=16):
+                 config_width=16):
 
         super().__init__(f"sched_gen")
 
         self.iterator_support = iterator_support
         self.config_width = config_width
-        self.glbl_cyc_width = glbl_cyc_width
         # Create params for instancing this module...
         self.iterator_support_par = self.param("ITERATOR_SUPPORT", clog2(iterator_support) + 1, value=self.iterator_support)
         self.config_width_par = self.param("CONFIG_WIDTH", clog2(config_width) + 1, value=self.config_width)
@@ -34,10 +32,10 @@ class SchedGen(Generator):
 
         # VARS
         self._valid_out = self.var("valid_out", 1)
-        self._cycle_count = self.input("cycle_count", self.glbl_cyc_width)
+        self._cycle_count = self.input("cycle_count", self.config_width)
         self._mux_sel = self.input("mux_sel", max(clog2(self.iterator_support), 1))
         self._addr_out = self.var("addr_out", self.config_width)
-        self._zext_addr_out = self._addr_out.extend(self._cycle_count.width)
+        # self._zext_addr_out = self._addr_out.extend(self._cycle_count.width)
 
         # Compare based on minimum of addr + global cycle...
         self.c_a_cmp = min(self._cycle_count.width, self._addr_out.width)
@@ -60,7 +58,7 @@ class SchedGen(Generator):
 
     @always_comb
     def set_valid_out(self):
-        if self._cycle_count == self._zext_addr_out:
+        if self._cycle_count == self._addr_out:
             self._valid_out = 1
         else:
             self._valid_out = 0

--- a/lake/modules/sram.py
+++ b/lake/modules/sram.py
@@ -174,7 +174,7 @@ class SRAM(Generator):
     @always_comb
     def set_mem_addr(self):
         # these ranges are inclusive
-        if num_tiles == 1:
+        if self.num_tiles == 1:
             self._mem_addr_to_sram = self._mem_addr_in_bank
         else:
             self._mem_addr_to_sram = self._mem_addr_in_bank[self.address_width - self.chain_idx_bits - 1, 0]

--- a/lake/modules/strg_ub_vec.py
+++ b/lake/modules/strg_ub_vec.py
@@ -169,7 +169,7 @@ class StrgUBVec(Generator):
 
         for i in range(self.interconnect_input_ports):
 
-            self.agg_iter_support = 4
+            self.agg_iter_support = 6
             self.agg_addr_width = 4
             self.agg_range_width = 16
 

--- a/lake/modules/strg_ub_vec.py
+++ b/lake/modules/strg_ub_vec.py
@@ -8,7 +8,7 @@ from lake.modules.sram_stub import SRAMStub
 from lake.modules.for_loop import ForLoop
 from lake.modules.addr_gen import AddrGen
 from lake.modules.spec.sched_gen import SchedGen
-from lake.utils.util import safe_wire
+from lake.utils.util import safe_wire, add_counter
 import kratos as kts
 
 
@@ -60,8 +60,7 @@ class StrgUBVec(Generator):
                                    explicit_array=True)
 
         # Create cycle counter to share...
-        self._cycle_count = self.var("cycle_count", 16)
-        self.add_code(self.increment_cycle_count)
+        self._cycle_count = add_counter(self, "cycle_count", 16)
 
         # outputs
         self._data_out = self.output("data_out", self.data_width,

--- a/lake/passes/passes.py
+++ b/lake/passes/passes.py
@@ -9,6 +9,12 @@ import _kratos
 
 # this is a pass
 def lift_config_reg(generator):
+    # if not hasattr(generator, "lifted"):
+    #     setattr(generator, "lifted", False)
+    # if generator.lifted:
+    #     print("WARNING: LAKE PASSES: LIFT_CONFIG_REGS: Configuration registers have already been lifted...")
+    #     print("WARNING: LAKE PASSES: LIFT_CONFIG_REGS: Exiting pass early...")
+    #     return
     class ConfigRegLiftVisitor(IRVisitor):
         def __init__(self):
             IRVisitor.__init__(self)
@@ -55,6 +61,8 @@ def lift_config_reg(generator):
 
     v = ConfigRegLiftVisitor()
     v.visit_root(generator)
+    # Make sure we don't lift twice
+    # generator.lifted = True
 
 
 # Inputs:

--- a/lake/passes/passes.py
+++ b/lake/passes/passes.py
@@ -43,7 +43,7 @@ def lift_config_reg(generator):
                     while parent_gen is not None:
                         # create a port based on the target's definition
                         new_name = child_gen.instance_name + "_" + child_port.name
-                        p = parent_gen.port(child_port, new_name)
+                        p = parent_gen.port(child_port, new_name, False)
                         parent_gen.wire(child_port, p)
                         # move up the hierarchy
                         child_port = p

--- a/lake/top/pond.py
+++ b/lake/top/pond.py
@@ -144,7 +144,8 @@ class Pond(Generator):
                            clk=self._gclk,
                            rst_n=self._rst_n,
                            step=self._write[wr_port],
-                           mux_sel=RF_WRITE_ITER.ports.mux_sel_out)
+                           mux_sel=RF_WRITE_ITER.ports.mux_sel_out,
+                           restart=RF_WRITE_ITER.ports.restart)
             safe_wire(self, self._write_addr[wr_port], RF_WRITE_ADDR.ports.addr_out)
 
             self.add_child(f"rf_write_sched_{wr_port}",
@@ -176,7 +177,8 @@ class Pond(Generator):
                            clk=self._gclk,
                            rst_n=self._rst_n,
                            step=self._read[rd_port],
-                           mux_sel=RF_READ_ITER.ports.mux_sel_out)
+                           mux_sel=RF_READ_ITER.ports.mux_sel_out,
+                           restart=RF_READ_ITER.ports.restart)
             safe_wire(self, self._read_addr[rd_port], RF_READ_ADDR.ports.addr_out)
 
             self.add_child(f"rf_read_sched_{rd_port}",

--- a/lake/top/pond.py
+++ b/lake/top/pond.py
@@ -64,6 +64,8 @@ class Pond(Generator):
                                     size=self.interconnect_input_ports,
                                     explicit_array=True,
                                     packed=True)
+        
+        # Add "_pond" suffix to avoid error during garnet RTL generation 
         self._data_in = self.input("data_in_pond", self.data_width,
                                    size=self.interconnect_input_ports,
                                    explicit_array=True,

--- a/lake/top/pond.py
+++ b/lake/top/pond.py
@@ -64,8 +64,8 @@ class Pond(Generator):
                                     size=self.interconnect_input_ports,
                                     explicit_array=True,
                                     packed=True)
-        
-        # Add "_pond" suffix to avoid error during garnet RTL generation 
+
+        # Add "_pond" suffix to avoid error during garnet RTL generation
         self._data_in = self.input("data_in_pond", self.data_width,
                                    size=self.interconnect_input_ports,
                                    explicit_array=True,

--- a/lake/top/pond.py
+++ b/lake/top/pond.py
@@ -12,7 +12,6 @@ from lake.attributes.control_signal_attr import ControlSignalAttr
 from lake.modules.storage_config_seq import StorageConfigSeq
 from lake.utils.parse_clkwork_config import extract_controller_json, map_controller
 from lake.utils.parse_clkwork_config import ControllerInfo
-from lake.utils.util import create_list_from_ctrl
 from _kratos import create_wrapper_flatten
 
 

--- a/lake/top/pond.py
+++ b/lake/top/pond.py
@@ -1,0 +1,318 @@
+import kratos as kts
+from kratos import *
+from lake.passes.passes import lift_config_reg
+from lake.modules.for_loop import ForLoop
+from lake.modules.addr_gen import AddrGen
+from lake.utils.util import extract_formal_annotation, safe_wire
+from lake.attributes.formal_attr import FormalAttr, FormalSignalConstraint
+from lake.modules.register_file import RegisterFile
+from lake.attributes.config_reg_attr import ConfigRegAttr
+from lake.attributes.control_signal_attr import ControlSignalAttr
+from lake.modules.storage_config_seq import StorageConfigSeq
+
+
+class Pond(Generator):
+    def __init__(self,
+                 data_width=16,  # CGRA Params
+                 mem_depth=32,
+                 default_iterator_support=2,
+                 interconnect_input_ports=1,  # Connection to int
+                 interconnect_output_ports=1,
+                 config_data_width=32,
+                 config_addr_width=8,
+                 add_clk_enable=True,
+                 add_flush=True):
+        super().__init__("pond", debug=True)
+
+        self.interconnect_input_ports = interconnect_input_ports
+        self.interconnect_output_ports = interconnect_output_ports
+        self.mem_depth = mem_depth
+        self.data_width = data_width
+        self.config_data_width = config_data_width
+        self.config_addr_width = config_addr_width
+        self.add_clk_enable = add_clk_enable
+        self.add_flush = add_flush
+
+        self.default_iterator_support = default_iterator_support
+        self.default_config_width = kts.clog2(self.mem_depth)
+        # inputs
+        self._clk = self.clock("clk")
+        self._clk.add_attribute(FormalAttr(f"{self._clk.name}", FormalSignalConstraint.CLK))
+        self._rst_n = self.reset("rst_n")
+        self._rst_n.add_attribute(FormalAttr(f"{self._rst_n.name}", FormalSignalConstraint.RSTN))
+        self._clk_en = self.clock_en("clk_en", 1)
+
+        # Enable/Disable tile
+        self._tile_en = self.input("tile_en", 1)
+        self._tile_en.add_attribute(ConfigRegAttr("Tile logic enable manifested as clock gate"))
+
+        gclk = self.var("gclk", 1)
+        self._gclk = kts.util.clock(gclk)
+        self.wire(gclk, kts.util.clock(self._clk & self._tile_en))
+
+        # Create write enable + addr, same for read.
+        self._write = self.input("write", self.interconnect_input_ports)
+        self._write.add_attribute(ControlSignalAttr(is_control=True))
+
+        self._write_addr = self.var("write_addr",
+                                    kts.clog2(self.mem_depth),
+                                    size=self.interconnect_input_ports,
+                                    explicit_array=True,
+                                    packed=True)
+        self._data_in = self.input("data_in", self.data_width,
+                                   size=self.interconnect_input_ports,
+                                   explicit_array=True,
+                                   packed=True)
+        self._data_in.add_attribute(FormalAttr(f"{self._data_in.name}", FormalSignalConstraint.SEQUENCE))
+        self._data_in.add_attribute(ControlSignalAttr(is_control=False))
+
+        self._read = self.input("read", self.interconnect_output_ports)
+        self._read.add_attribute(ControlSignalAttr(is_control=True))
+
+        self._read_addr = self.var("read_addr",
+                                   kts.clog2(self.mem_depth),
+                                   size=self.interconnect_output_ports,
+                                   explicit_array=True,
+                                   packed=True)
+        self._data_out = self.output("data_out", self.data_width,
+                                     size=self.interconnect_output_ports,
+                                     explicit_array=True,
+                                     packed=True)
+        self._data_out.add_attribute(FormalAttr(f"{self._data_out.name}", FormalSignalConstraint.SEQUENCE))
+        self._data_out.add_attribute(ControlSignalAttr(is_control=False))
+
+        self._valid_out = self.output("valid_out", self.interconnect_output_ports)
+        self._valid_out.add_attribute(FormalAttr(f"{self._valid_out.name}", FormalSignalConstraint.SEQUENCE))
+        self._valid_out.add_attribute(ControlSignalAttr(is_control=False))
+
+        self._mem_data_out = self.var("mem_data_out", self.data_width,
+                                      size=self.interconnect_output_ports,
+                                      explicit_array=True,
+                                      packed=True)
+
+        self._mem_data_in = self.var("mem_data_in", self.data_width,
+                                     size=self.interconnect_input_ports,
+                                     explicit_array=True,
+                                     packed=True)
+
+        self._mem_write_addr = self.var("mem_write_addr",
+                                        kts.clog2(self.mem_depth),
+                                        size=self.interconnect_input_ports,
+                                        explicit_array=True,
+                                        packed=True)
+
+        self._mem_read_addr = self.var("mem_read_addr",
+                                       kts.clog2(self.mem_depth),
+                                       size=self.interconnect_output_ports,
+                                       explicit_array=True,
+                                       packed=True)
+
+        self.wire(self._data_out, self._mem_data_out)
+
+        # Valid out is simply passing the read signal through...
+        self.wire(self._valid_out, self._read)
+
+        # Create write addressors
+        for wr_port in range(self.interconnect_input_ports):
+
+            RF_WRITE_ITER = ForLoop(iterator_support=self.default_iterator_support,
+                                    config_width=self.default_config_width)
+            RF_WRITE_ADDR = AddrGen(iterator_support=self.default_iterator_support,
+                                    config_width=self.default_config_width)
+
+            self.add_child(f"rf_write_iter_{wr_port}",
+                           RF_WRITE_ITER,
+                           clk=self._gclk,
+                           rst_n=self._rst_n,
+                           step=self._write[wr_port])
+            # Whatever comes through here should hopefully just pipe through seamlessly
+            # addressor modules
+            self.add_child(f"rf_write_addr_{wr_port}",
+                           RF_WRITE_ADDR,
+                           clk=self._gclk,
+                           rst_n=self._rst_n,
+                           step=self._write[wr_port],
+                           mux_sel=RF_WRITE_ITER.ports.mux_sel_out)
+            safe_wire(self, self._write_addr[wr_port], RF_WRITE_ADDR.ports.addr_out)
+
+        # Create read addressors
+        for rd_port in range(self.interconnect_output_ports):
+
+            RF_READ_ITER = ForLoop(iterator_support=self.default_iterator_support,
+                                   config_width=self.default_config_width)
+            RF_READ_ADDR = AddrGen(iterator_support=self.default_iterator_support,
+                                   config_width=self.default_config_width)
+
+            self.add_child(f"rf_read_iter_{rd_port}",
+                           RF_READ_ITER,
+                           clk=self._gclk,
+                           rst_n=self._rst_n,
+                           step=self._read[rd_port])
+
+            self.add_child(f"rf_read_addr_{rd_port}",
+                           RF_READ_ADDR,
+                           clk=self._gclk,
+                           rst_n=self._rst_n,
+                           step=self._read[rd_port],
+                           mux_sel=RF_READ_ITER.ports.mux_sel_out)
+            safe_wire(self, self._read_addr[rd_port], RF_READ_ADDR.ports.addr_out)
+
+        # ===================================
+        # Instantiate config hooks...
+        # ===================================
+        self.fw_int = 1
+        self.data_words_per_set = 2 ** self.config_addr_width
+        self.sets = int((self.fw_int * self.mem_depth) / self.data_words_per_set)
+
+        self.sets_per_macro = max(1, int(self.mem_depth / self.data_words_per_set))
+        self.total_sets = max(1, 1 * self.sets_per_macro)
+
+        self._config_data_in = self.input("config_data_in",
+                                          self.config_data_width)
+        self._config_data_in.add_attribute(ControlSignalAttr(is_control=False))
+
+        self._config_data_in_shrt = self.var("config_data_in_shrt",
+                                             self.data_width)
+
+        self.wire(self._config_data_in_shrt, self._config_data_in[self.data_width - 1, 0])
+
+        self._config_addr_in = self.input("config_addr_in",
+                                          self.config_addr_width)
+        self._config_addr_in.add_attribute(ControlSignalAttr(is_control=False))
+
+        self._config_data_out_shrt = self.var("config_data_out_shrt", self.data_width,
+                                              size=self.total_sets,
+                                              explicit_array=True,
+                                              packed=True)
+
+        self._config_data_out = self.output("config_data_out", self.config_data_width,
+                                            size=self.total_sets,
+                                            explicit_array=True,
+                                            packed=True)
+        self._config_data_out.add_attribute(ControlSignalAttr(is_control=False))
+
+        for i in range(self.total_sets):
+            self.wire(self._config_data_out[i],
+                      self._config_data_out_shrt[i].extend(self.config_data_width))
+
+        self._config_read = self.input("config_read", 1)
+        self._config_read.add_attribute(ControlSignalAttr(is_control=False))
+
+        self._config_write = self.input("config_write", 1)
+        self._config_write.add_attribute(ControlSignalAttr(is_control=False))
+
+        self._config_en = self.input("config_en", self.total_sets)
+        self._config_en.add_attribute(ControlSignalAttr(is_control=False))
+
+        self._mem_data_cfg = self.var("mem_data_cfg", self.data_width,
+                                      explicit_array=True,
+                                      packed=True)
+
+        self._mem_addr_cfg = self.var("mem_addr_cfg", kts.clog2(self.mem_depth))
+
+        # Add config...
+        stg_cfg_seq = StorageConfigSeq(data_width=self.data_width,
+                                       config_addr_width=self.config_addr_width,
+                                       addr_width=kts.clog2(self.mem_depth),
+                                       fetch_width=self.data_width,
+                                       total_sets=self.total_sets,
+                                       sets_per_macro=self.sets_per_macro)
+
+        # The clock to config sequencer needs to be the normal clock or
+        # if the tile is off, we bring the clock back in based on config_en
+        cfg_seq_clk = self.var("cfg_seq_clk", 1)
+        self._cfg_seq_clk = kts.util.clock(cfg_seq_clk)
+        self.wire(cfg_seq_clk, kts.util.clock(self._gclk))
+
+        self.add_child(f"config_seq", stg_cfg_seq,
+                       clk=self._cfg_seq_clk,
+                       rst_n=self._rst_n,
+                       clk_en=self._clk_en | self._config_en.r_or(),
+                       config_data_in=self._config_data_in_shrt,
+                       config_addr_in=self._config_addr_in,
+                       config_wr=self._config_write,
+                       config_rd=self._config_read,
+                       config_en=self._config_en,
+                       wr_data=self._mem_data_cfg,
+                       rd_data_out=self._config_data_out_shrt,
+                       addr_out=self._mem_addr_cfg)
+
+        if self.interconnect_output_ports == 1:
+            self.wire(stg_cfg_seq.ports.rd_data_stg, self._mem_data_out)
+        else:
+            self.wire(stg_cfg_seq.ports.rd_data_stg[0], self._mem_data_out[0])
+
+        self.RF_GEN = RegisterFile(data_width=self.data_width,
+                                   write_ports=self.interconnect_input_ports,
+                                   read_ports=self.interconnect_output_ports,
+                                   width_mult=1,
+                                   depth=self.mem_depth,
+                                   read_delay=0)
+
+        # Now we can instantiate and wire up the register file
+        self.add_child(f"rf",
+                       self.RF_GEN,
+                       clk=self._gclk,
+                       rst_n=self._rst_n,
+                       data_out=self._mem_data_out)
+
+        # Opt in for config_write
+        self._write_rf = self.var("write_rf", self.interconnect_input_ports)
+        self.wire(self._write_rf[0], kts.ternary(self._config_en.r_or(), self._config_write, self._write[0]))
+        for i in range(self.interconnect_input_ports - 1):
+            self.wire(self._write_rf[i + 1], kts.ternary(self._config_en.r_or(), kts.const(0, 1), self._write[i + 1]))
+        self.wire(self.RF_GEN.ports.wen, self._write_rf)
+
+        # Opt in for config_data_in
+        self.wire(self._mem_data_in[0], kts.ternary(self._config_en.r_or(), self._mem_data_cfg, self._data_in[0]))
+        for i in range(self.interconnect_input_ports - 1):
+            self.wire(self._mem_data_in[i + 1], self._data_in[i + 1])
+        self.wire(self.RF_GEN.ports.data_in, self._mem_data_in)
+
+        # Opt in for config_addr
+        self.wire(self._mem_write_addr[0], kts.ternary(self._config_en.r_or(),
+                                                       self._mem_addr_cfg,
+                                                       self._write_addr[0]))
+        for i in range(self.interconnect_input_ports - 1):
+            self.wire(self._mem_write_addr[i + 1], self._write_addr[i + 1])
+        if self.interconnect_input_ports == 1:
+            self.wire(self.RF_GEN.ports.wr_addr, self._mem_write_addr[0])
+        else:
+            self.wire(self.RF_GEN.ports.wr_addr, self._mem_write_addr)
+
+        self.wire(self._mem_read_addr[0], kts.ternary(self._config_en.r_or(),
+                                                      self._mem_addr_cfg,
+                                                      self._read_addr[0]))
+        for i in range(self.interconnect_output_ports - 1):
+            self.wire(self._mem_read_addr[i + 1], self._read_addr[i + 1])
+        if self.interconnect_output_ports == 1:
+            self.wire(self.RF_GEN.ports.rd_addr, self._mem_read_addr[0])
+        else:
+            self.wire(self.RF_GEN.ports.rd_addr, self._mem_read_addr)
+
+        if self.add_clk_enable:
+            # self.clock_en("clk_en")
+            kts.passes.auto_insert_clock_enable(self.internal_generator)
+            clk_en_port = self.internal_generator.get_port("clk_en")
+            clk_en_port.add_attribute(ControlSignalAttr(False))
+
+        if self.add_flush:
+            self.add_attribute("sync-reset=flush")
+            kts.passes.auto_insert_sync_reset(self.internal_generator)
+            flush_port = self.internal_generator.get_port("flush")
+            flush_port.add_attribute(ControlSignalAttr(True))
+
+
+if __name__ == "__main__":
+    pond_dut = Pond(data_width=16,  # CGRA Params
+                    mem_depth=32,
+                    default_iterator_support=2,
+                    interconnect_input_ports=1,  # Connection to int
+                    interconnect_output_ports=1)
+
+    # Lift config regs and generate annotation
+    lift_config_reg(pond_dut.internal_generator)
+    extract_formal_annotation(pond_dut, "pond.txt")
+
+    verilog(pond_dut, filename="pond.sv",
+            optimize_if=False)

--- a/lake/top/pond.py
+++ b/lake/top/pond.py
@@ -327,19 +327,22 @@ class Pond(Generator):
             flush_port = self.internal_generator.get_port("flush")
             flush_port.add_attribute(ControlSignalAttr(True))
 
+        # Finally, lift the config regs...
+        lift_config_reg(self.internal_generator)
+
 
 if __name__ == "__main__":
     pond_dut = Pond(data_width=16,  # CGRA Params
-                    mem_depth=65536,
-                    default_iterator_support=16,
-                    interconnect_input_ports=48,  # Connection to int
-                    interconnect_output_ports=48,
-                    cycle_count_width=32,
+                    mem_depth=32,
+                    default_iterator_support=2,
+                    interconnect_input_ports=1,  # Connection to int
+                    interconnect_output_ports=1,
+                    cycle_count_width=16,
                     add_clk_enable=True,
                     add_flush=True)
 
     # Lift config regs and generate annotation
-    lift_config_reg(pond_dut.internal_generator)
+    # lift_config_reg(pond_dut.internal_generator)
     extract_formal_annotation(pond_dut, "pond.txt")
 
     verilog(pond_dut, filename="pond.sv",

--- a/lake/top/pond.py
+++ b/lake/top/pond.py
@@ -64,7 +64,7 @@ class Pond(Generator):
                                     size=self.interconnect_input_ports,
                                     explicit_array=True,
                                     packed=True)
-        self._data_in = self.input("data_in", self.data_width,
+        self._data_in = self.input("data_in_pond", self.data_width,
                                    size=self.interconnect_input_ports,
                                    explicit_array=True,
                                    packed=True)
@@ -79,14 +79,14 @@ class Pond(Generator):
                                    size=self.interconnect_output_ports,
                                    explicit_array=True,
                                    packed=True)
-        self._data_out = self.output("data_out", self.data_width,
+        self._data_out = self.output("data_out_pond", self.data_width,
                                      size=self.interconnect_output_ports,
                                      explicit_array=True,
                                      packed=True)
         self._data_out.add_attribute(FormalAttr(f"{self._data_out.name}", FormalSignalConstraint.SEQUENCE))
         self._data_out.add_attribute(ControlSignalAttr(is_control=False))
 
-        self._valid_out = self.output("valid_out", self.interconnect_output_ports)
+        self._valid_out = self.output("valid_out_pond", self.interconnect_output_ports)
         self._valid_out.add_attribute(FormalAttr(f"{self._valid_out.name}", FormalSignalConstraint.SEQUENCE))
         self._valid_out.add_attribute(ControlSignalAttr(is_control=False))
 

--- a/lake/top/pond.py
+++ b/lake/top/pond.py
@@ -253,7 +253,7 @@ class Pond(Generator):
         self.add_child(f"rf",
                        self.RF_GEN,
                        clk=self._gclk,
-                       rst_n=self._rst_n,
+                       # rst_n=self._rst_n,
                        data_out=self._mem_data_out)
 
         # Opt in for config_write

--- a/lake/top/pond.py
+++ b/lake/top/pond.py
@@ -126,7 +126,7 @@ class Pond(Generator):
         for wr_port in range(self.interconnect_input_ports):
 
             RF_WRITE_ITER = ForLoop(iterator_support=self.default_iterator_support,
-                                    config_width=self.default_config_width)
+                                    config_width=self.cycle_count_width)
             RF_WRITE_ADDR = AddrGen(iterator_support=self.default_iterator_support,
                                     config_width=self.default_config_width)
             RF_WRITE_SCHED = SchedGen(iterator_support=self.default_iterator_support,
@@ -160,7 +160,7 @@ class Pond(Generator):
         for rd_port in range(self.interconnect_output_ports):
 
             RF_READ_ITER = ForLoop(iterator_support=self.default_iterator_support,
-                                   config_width=self.default_config_width)
+                                   config_width=self.cycle_count_width)
             RF_READ_ADDR = AddrGen(iterator_support=self.default_iterator_support,
                                    config_width=self.default_config_width)
             RF_READ_SCHED = SchedGen(iterator_support=self.default_iterator_support,

--- a/lake/utils/util.py
+++ b/lake/utils/util.py
@@ -1,4 +1,5 @@
 import kratos as kts
+from kratos import *
 import math
 import os as os
 from enum import Enum
@@ -184,3 +185,18 @@ def trim_config(flat_gen, cfg_reg_name, value):
     bmask = int(math.pow(2, cfg_port.width)) - 1
     print(f"Port name: {cfg_reg_name}, Port width: {cfg_port.width}, corresponding mask_val: {bmask}")
     return (cfg_reg_name, value & bmask)
+
+
+# Add a simple counter to a design and return the signal
+def add_counter(generator, name, bitwidth):
+    ctr = generator.var(name, bitwidth)
+
+    @always_ff((posedge, "clk"), (negedge, "rst_n"))
+    def ctr_inc_code():
+        if ~generator._rst_n:
+            ctr = 0
+        else:
+            ctr = ctr + 1
+
+    generator.add_code(ctr_inc_code)
+    return ctr

--- a/lake/utils/util.py
+++ b/lake/utils/util.py
@@ -200,3 +200,34 @@ def add_counter(generator, name, bitwidth):
 
     generator.add_code(ctr_inc_code)
     return ctr
+
+# Function for generating Pond API
+def generate_pond_api(ctrl_rd, ctrl_wr):
+    (tform_ranges_rd, tform_strides_rd) = transform_strides_and_ranges(ctrl_rd[0], ctrl_rd[1], ctrl_rd[2])
+    (tform_ranges_wr, tform_strides_wr) = transform_strides_and_ranges(ctrl_wr[0], ctrl_wr[1], ctrl_wr[2])
+
+    new_config = {}
+
+    new_config["rf_read_iter_0_dimensionality"] = ctrl_rd[2]
+    new_config["rf_read_addr_0_starting_addr"] = ctrl_rd[3]
+    new_config["rf_read_addr_0_strides_0"] = tform_strides_rd[0]
+    new_config["rf_read_addr_0_strides_1"] = tform_strides_rd[1]
+    new_config["rf_read_iter_0_ranges_0"] = tform_ranges_rd[0]
+    new_config["rf_read_iter_0_ranges_1"] = tform_ranges_rd[1]
+          
+    new_config["rf_read_sched_0_sched_addr_gen_starting_addr"] = ctrl_rd[4]
+    new_config["rf_read_sched_0_sched_addr_gen_strides_0"] = tform_strides_rd[0]
+    new_config["rf_read_sched_0_sched_addr_gen_strides_1"] = tform_strides_rd[1]
+        
+    new_config["rf_write_iter_0_dimensionality"] = ctrl_wr[2]
+    new_config["rf_write_addr_0_starting_addr"] = ctrl_wr[3]
+    new_config["rf_write_addr_0_strides_0"] = tform_strides_wr[0]
+    new_config["rf_write_addr_0_strides_1"] = tform_strides_wr[1]
+    new_config["rf_write_iter_0_ranges_0"] = tform_ranges_wr[0]
+    new_config["rf_write_iter_0_ranges_1"] = tform_ranges_wr[1]
+    
+    new_config["rf_write_sched_0_sched_addr_gen_starting_addr"] = ctrl_wr[4]
+    new_config["rf_write_sched_0_sched_addr_gen_strides_0"] = tform_strides_wr[0]
+    new_config["rf_write_sched_0_sched_addr_gen_strides_1"] = tform_strides_wr[1]
+    
+    return new_config

--- a/lake/utils/util.py
+++ b/lake/utils/util.py
@@ -201,6 +201,7 @@ def add_counter(generator, name, bitwidth):
     generator.add_code(ctr_inc_code)
     return ctr
 
+
 # Function for generating Pond API
 def generate_pond_api(ctrl_rd, ctrl_wr):
     (tform_ranges_rd, tform_strides_rd) = transform_strides_and_ranges(ctrl_rd[0], ctrl_rd[1], ctrl_rd[2])
@@ -214,20 +215,20 @@ def generate_pond_api(ctrl_rd, ctrl_wr):
     new_config["rf_read_addr_0_strides_1"] = tform_strides_rd[1]
     new_config["rf_read_iter_0_ranges_0"] = tform_ranges_rd[0]
     new_config["rf_read_iter_0_ranges_1"] = tform_ranges_rd[1]
-          
+
     new_config["rf_read_sched_0_sched_addr_gen_starting_addr"] = ctrl_rd[4]
     new_config["rf_read_sched_0_sched_addr_gen_strides_0"] = tform_strides_rd[0]
     new_config["rf_read_sched_0_sched_addr_gen_strides_1"] = tform_strides_rd[1]
-        
+
     new_config["rf_write_iter_0_dimensionality"] = ctrl_wr[2]
     new_config["rf_write_addr_0_starting_addr"] = ctrl_wr[3]
     new_config["rf_write_addr_0_strides_0"] = tform_strides_wr[0]
     new_config["rf_write_addr_0_strides_1"] = tform_strides_wr[1]
     new_config["rf_write_iter_0_ranges_0"] = tform_ranges_wr[0]
     new_config["rf_write_iter_0_ranges_1"] = tform_ranges_wr[1]
-    
+
     new_config["rf_write_sched_0_sched_addr_gen_starting_addr"] = ctrl_wr[4]
     new_config["rf_write_sched_0_sched_addr_gen_strides_0"] = tform_strides_wr[0]
     new_config["rf_write_sched_0_sched_addr_gen_strides_1"] = tform_strides_wr[1]
-    
+
     return new_config

--- a/tests/test_pond.py
+++ b/tests/test_pond.py
@@ -4,7 +4,9 @@ import fault
 import random as rand
 import pytest
 import tempfile
-from lake.models.lake_top_model import LakeTopModel
+from lake.top.pond import Pond
+from lake.passes.passes import lift_config_reg
+from lake.utils.util import extract_formal_annotation
 
 
 # Deprecated on old pond...
@@ -180,6 +182,19 @@ def test_pond(data_width=16,  # CGRA Params
                                directory=tempdir,
                                magma_output="verilog",
                                flags=["-Wno-fatal"])
+
+
+@pytest.mark.parametrize("in_ports", [1, 2])
+@pytest.mark.parametrize("out_ports", [1, 2])
+def test_build_pond(in_ports,
+                    out_ports):
+    pond_dut = Pond(interconnect_input_ports=in_ports,
+                    interconnect_output_ports=out_ports)
+    lift_config_reg(pond_dut.internal_generator)
+    extract_formal_annotation(pond_dut, "pond.txt")
+
+    kts.verilog(pond_dut, filename=f"pond_{in_ports}_{out_ports}.sv",
+                optimize_if=False)
 
 
 if __name__ == "__main__":

--- a/tests/test_pond.py
+++ b/tests/test_pond.py
@@ -190,7 +190,6 @@ def test_build_pond(in_ports,
                     out_ports):
     pond_dut = Pond(interconnect_input_ports=in_ports,
                     interconnect_output_ports=out_ports)
-    lift_config_reg(pond_dut.internal_generator)
     extract_formal_annotation(pond_dut, "pond.txt")
 
     kts.verilog(pond_dut, filename=f"pond_{in_ports}_{out_ports}.sv",

--- a/tests/test_pond_conv_new.py
+++ b/tests/test_pond_conv_new.py
@@ -1,0 +1,205 @@
+from lake.top.lake_top import LakeTop
+from lake.top.pond import Pond
+import kratos as kts
+import fault
+import random as rand
+import pytest
+import tempfile
+from lake.models.lake_top_model import LakeTopModel
+from lake.utils.util import transform_strides_and_ranges
+
+
+ctrl_dim = 2
+ctrl_ranges = [16, 1]
+ctrl_strides = [1, 1]
+(tform_ranges, tform_strides) = transform_strides_and_ranges(ctrl_ranges, ctrl_strides, ctrl_dim)
+print(tform_ranges, tform_strides)
+# Deprecated on old pond...
+#@pytest.mark.skip
+def test_pond(data_width=16,  # CGRA Params
+              mem_depth=32,
+              default_iterator_support=2,
+              config_data_width=32,
+              config_addr_width=8,
+              cycle_count_width=16,
+              add_clk_enable=True,
+              add_flush=True,
+              #mem_depth=32,
+              #banks=1,
+              #input_iterator_support=2,  # Addr Controllers
+              #output_iterator_support=2,
+              interconnect_input_ports=1,  # Connection to int
+              interconnect_output_ports=1):
+              #mem_input_ports=1,
+              #mem_output_ports=1,
+              #use_sram_stub=1,
+              #read_delay=0,  # Cycle delay in read (SRAM vs Register File)
+              #rw_same_cycle=True,  # Does the memory allow r+w in same cycle?
+              #agg_height=0,
+              #transpose_height=0,  # new field
+              #max_agg_schedule=64,
+              #input_max_port_sched=64,
+              #output_max_port_sched=64,
+              #align_input=0,
+              #max_line_length=2048,
+              #max_tb_height=1,
+              #tb_range_max=2048,
+              #tb_range_inner_max=5,  # new field
+              #tb_sched_max=64,
+              #max_tb_stride=15,
+              #num_tb=0,
+              #tb_iterator_support=2,
+              #multiwrite=1,
+              #max_prefetch=64,
+              ##config_data_width=16,
+              ##config_addr_width=8,
+              #remove_tb=True):
+
+    new_config = {}
+
+    # Input addr ctrl
+    new_config["rf_read_iter_0_dimensionality"] = 2
+    #new_config["strg_ub_input_addr_ctrl_address_gen_0_starting_addr"] = 0
+    #new_config["strg_ub_input_addr_ctrl_address_gen_0_ranges_0"] = 16
+    #new_config["strg_ub_input_addr_ctrl_address_gen_0_strides_0"] = 1
+    #new_config["strg_ub_input_addr_ctrl_address_gen_0_ranges_1"] = 100
+    #new_config["strg_ub_input_addr_ctrl_address_gen_0_strides_1"] = 0
+
+    new_config["rf_write_iter_0_dimensionality_0"] = 2 
+    new_config["rf_read_addr_0_starting_addr"] = 2
+    new_config["rf_read_addr_0_strides"] = 1
+    new_config["rf_read_iter_0_dimensionality"] = 2
+    new_config["rf_read_iter_0_ranges"] = 16
+    new_config["rf_read_sched_0_sched_addr_gen_starting_addr"] = 0
+    new_config["rf_read_sched_0_sched_addr_gen_strides"] = 1
+    new_config["rf_write_addr_0_starting_addr"] = 0
+    new_config["rf_write_addr_0_strides"] = 1
+    new_config["rf_write_iter_0_dimensionality"] = 2
+    new_config["rf_write_iter_0_ranges"] = 16
+    new_config["rf_write_sched_0_sched_addr_gen_starting_addr"] = 0
+    new_config["rf_write_sched_0_sched_addr_gen_strides"] = 1
+
+    #new_config["strg_ub_input_addr_ctrl_address_gen_1_dimensionality"] = 2
+    #new_config["strg_ub_input_addr_ctrl_address_gen_1_starting_addr"] = 16
+    #new_config["strg_ub_input_addr_ctrl_address_gen_1_ranges_0"] = 16
+    #new_config["strg_ub_input_addr_ctrl_address_gen_1_strides_0"] = 1
+    #new_config["strg_ub_input_addr_ctrl_address_gen_1_ranges_1"] = 100
+    #new_config["strg_ub_input_addr_ctrl_address_gen_1_strides_1"] = 0
+
+    # Output addr ctrl
+    #new_config["strg_ub_output_addr_ctrl_address_gen_0_dimensionality"] = 2
+    #new_config["strg_ub_output_addr_ctrl_address_gen_0_starting_addr"] = 0
+    #new_config["strg_ub_output_addr_ctrl_address_gen_0_ranges_0"] = 16
+    #new_config["strg_ub_output_addr_ctrl_address_gen_0_strides_0"] = 1
+    #new_config["strg_ub_output_addr_ctrl_address_gen_0_ranges_1"] = 100
+    #new_config["strg_ub_output_addr_ctrl_address_gen_0_strides_1"] = 0
+
+    #new_config["strg_ub_output_addr_ctrl_address_gen_1_dimensionality"] = 2
+    #new_config["strg_ub_output_addr_ctrl_address_gen_1_starting_addr"] = 16
+    #new_config["strg_ub_output_addr_ctrl_address_gen_1_ranges_0"] = 16
+    #new_config["strg_ub_output_addr_ctrl_address_gen_1_strides_0"] = 1
+    #new_config["strg_ub_output_addr_ctrl_address_gen_1_ranges_1"] = 100
+    #new_config["strg_ub_output_addr_ctrl_address_gen_1_strides_1"] = 0
+
+    # These ports are desynched
+    # new_config["strg_ub_sync_grp_sync_group_0"] = 1  # not needed
+    # new_config["strg_ub_sync_grp_sync_group_1"] = 2  # not needed
+
+    #new_config["strg_ub_app_ctrl_read_depth_0"] = 16
+    #new_config["strg_ub_app_ctrl_read_depth_1"] = 16
+
+    #new_config["strg_ub_app_ctrl_write_depth_0"] = 16
+    #new_config["strg_ub_app_ctrl_write_depth_1"] = 16
+
+    #new_config["strg_ub_app_ctrl_coarse_read_depth_0"] = 16
+    #new_config["strg_ub_app_ctrl_coarse_read_depth_1"] = 0
+
+    #new_config["strg_ub_app_ctrl_coarse_write_depth_0"] = 16
+    #new_config["strg_ub_app_ctrl_coarse_write_depth_1"] = 16
+
+    #new_config["strg_ub_app_ctrl_write_depth_ss_0"] = 16
+    #new_config["strg_ub_app_ctrl_write_depth_ss_0"] = 16
+
+    # Don't use the model - this is handwritten for now
+
+    ### DUT
+    pond_dut = Pond(data_width=data_width,  # CGRA Params
+                    mem_depth=mem_depth,
+                    default_iterator_support=default_iterator_support,
+                    interconnect_input_ports=interconnect_input_ports,  # Connection to int
+                    interconnect_output_ports=interconnect_output_ports,
+                    config_data_width=config_data_width,
+                    config_addr_width=config_addr_width,
+                    cycle_count_width=cycle_count_width,
+                    add_clk_enable=add_clk_enable,
+                    add_flush=add_flush)
+
+    magma_dut = kts.util.to_magma(pond_dut,
+                                  flatten_array=True,
+                                  check_multiple_driver=False,
+                                  optimize_if=False,
+                                  check_flip_flop_always_ff=False)
+
+    tester = fault.Tester(magma_dut, magma_dut.clk)
+    ###
+    for key, value in new_config.items():
+        setattr(tester.circuit, key, value)
+
+    rand.seed(0)
+    tester.circuit.clk = 0
+    tester.circuit.clk_en = 1
+    tester.circuit.tile_en = 1
+    tester.circuit.rst_n = 0
+    tester.step(2)
+    tester.circuit.rst_n = 1
+    tester.step(2)
+    tester.circuit.clk_en = 1
+
+    data_in = [0] * interconnect_input_ports
+    valid_in = [0] * interconnect_input_ports
+    wen_en = 0
+    ren_en = 0
+    addr_in = 0
+    ren = 0
+    # data_in[1] = 15
+    for i in range(32):
+        # Incrementing Data
+        data_in[0] = data_in[0] + 1
+        # data_in[1] = data_in[1] + 1
+
+        wen_en = 3
+        wen = 3
+
+        ren_en = 0
+        ren = 0
+
+        if i >= 16:
+            wen_en = 0
+            wen = 0
+            ren_en = 3
+            ren = 3
+
+        # tester.circuit.addr_in = addr_in
+        tester.circuit.wen_en = wen_en
+        tester.circuit.wen_in = wen
+        tester.circuit.ren_en = ren_en
+        tester.circuit.ren_in = ren
+
+        if interconnect_input_ports == 1:
+            tester.circuit.data_in = data_in[0]
+        else:
+            for j in range(interconnect_input_ports):
+                setattr(tester.circuit, f"data_in_{j}", data_in[j])
+        # print("data0 and data1", data_in[0], data_in[1])
+        tester.eval()
+        tester.step(2)
+
+    with tempfile.TemporaryDirectory() as tempdir:
+        tester.compile_and_run(target="verilator",
+                               directory=tempdir,
+                               magma_output="verilog",
+                               flags=["-Wno-fatal"])
+
+
+if __name__ == "__main__":
+    test_pond()

--- a/tests/test_pond_conv_new.py
+++ b/tests/test_pond_conv_new.py
@@ -9,13 +9,13 @@ from lake.models.lake_top_model import LakeTopModel
 from lake.utils.util import transform_strides_and_ranges
 
 
-ctrl_dim = 2
-ctrl_ranges = [16, 1]
-ctrl_strides = [1, 1]
-(tform_ranges, tform_strides) = transform_strides_and_ranges(ctrl_ranges, ctrl_strides, ctrl_dim)
-print(tform_ranges, tform_strides)
-# Deprecated on old pond...
-#@pytest.mark.skip
+# ctrl_dim = 2
+# ctrl_ranges = [16, 1]
+# ctrl_strides = [1, 1]
+# (tform_ranges, tform_strides) = transform_strides_and_ranges(ctrl_ranges, ctrl_strides, ctrl_dim)
+# print(tform_ranges, tform_strides)
+# # Deprecated on old pond...
+# #@pytest.mark.skip
 def test_pond(data_width=16,  # CGRA Params
               mem_depth=32,
               default_iterator_support=2,
@@ -24,48 +24,20 @@ def test_pond(data_width=16,  # CGRA Params
               cycle_count_width=16,
               add_clk_enable=True,
               add_flush=True,
-              #mem_depth=32,
-              #banks=1,
-              #input_iterator_support=2,  # Addr Controllers
-              #output_iterator_support=2,
               interconnect_input_ports=1,  # Connection to int
               interconnect_output_ports=1):
-              #mem_input_ports=1,
-              #mem_output_ports=1,
-              #use_sram_stub=1,
-              #read_delay=0,  # Cycle delay in read (SRAM vs Register File)
-              #rw_same_cycle=True,  # Does the memory allow r+w in same cycle?
-              #agg_height=0,
-              #transpose_height=0,  # new field
-              #max_agg_schedule=64,
-              #input_max_port_sched=64,
-              #output_max_port_sched=64,
-              #align_input=0,
-              #max_line_length=2048,
-              #max_tb_height=1,
-              #tb_range_max=2048,
-              #tb_range_inner_max=5,  # new field
-              #tb_sched_max=64,
-              #max_tb_stride=15,
-              #num_tb=0,
-              #tb_iterator_support=2,
-              #multiwrite=1,
-              #max_prefetch=64,
-              ##config_data_width=16,
-              ##config_addr_width=8,
-              #remove_tb=True):
 
     new_config = {}
 
     # Input addr ctrl
     new_config["rf_read_iter_0_dimensionality"] = 2
-    #new_config["strg_ub_input_addr_ctrl_address_gen_0_starting_addr"] = 0
-    #new_config["strg_ub_input_addr_ctrl_address_gen_0_ranges_0"] = 16
-    #new_config["strg_ub_input_addr_ctrl_address_gen_0_strides_0"] = 1
-    #new_config["strg_ub_input_addr_ctrl_address_gen_0_ranges_1"] = 100
-    #new_config["strg_ub_input_addr_ctrl_address_gen_0_strides_1"] = 0
+    # new_config["strg_ub_input_addr_ctrl_address_gen_0_starting_addr"] = 0
+    # new_config["strg_ub_input_addr_ctrl_address_gen_0_ranges_0"] = 16
+    # new_config["strg_ub_input_addr_ctrl_address_gen_0_strides_0"] = 1
+    # new_config["strg_ub_input_addr_ctrl_address_gen_0_ranges_1"] = 100
+    # new_config["strg_ub_input_addr_ctrl_address_gen_0_strides_1"] = 0
 
-    new_config["rf_write_iter_0_dimensionality_0"] = 2 
+    new_config["rf_write_iter_0_dimensionality_0"] = 2
     new_config["rf_read_addr_0_starting_addr"] = 2
     new_config["rf_read_addr_0_strides"] = 1
     new_config["rf_read_iter_0_dimensionality"] = 2
@@ -79,46 +51,46 @@ def test_pond(data_width=16,  # CGRA Params
     new_config["rf_write_sched_0_sched_addr_gen_starting_addr"] = 0
     new_config["rf_write_sched_0_sched_addr_gen_strides"] = 1
 
-    #new_config["strg_ub_input_addr_ctrl_address_gen_1_dimensionality"] = 2
-    #new_config["strg_ub_input_addr_ctrl_address_gen_1_starting_addr"] = 16
-    #new_config["strg_ub_input_addr_ctrl_address_gen_1_ranges_0"] = 16
-    #new_config["strg_ub_input_addr_ctrl_address_gen_1_strides_0"] = 1
-    #new_config["strg_ub_input_addr_ctrl_address_gen_1_ranges_1"] = 100
-    #new_config["strg_ub_input_addr_ctrl_address_gen_1_strides_1"] = 0
+    # new_config["strg_ub_input_addr_ctrl_address_gen_1_dimensionality"] = 2
+    # new_config["strg_ub_input_addr_ctrl_address_gen_1_starting_addr"] = 16
+    # new_config["strg_ub_input_addr_ctrl_address_gen_1_ranges_0"] = 16
+    # new_config["strg_ub_input_addr_ctrl_address_gen_1_strides_0"] = 1
+    # new_config["strg_ub_input_addr_ctrl_address_gen_1_ranges_1"] = 100
+    # new_config["strg_ub_input_addr_ctrl_address_gen_1_strides_1"] = 0
 
     # Output addr ctrl
-    #new_config["strg_ub_output_addr_ctrl_address_gen_0_dimensionality"] = 2
-    #new_config["strg_ub_output_addr_ctrl_address_gen_0_starting_addr"] = 0
-    #new_config["strg_ub_output_addr_ctrl_address_gen_0_ranges_0"] = 16
-    #new_config["strg_ub_output_addr_ctrl_address_gen_0_strides_0"] = 1
-    #new_config["strg_ub_output_addr_ctrl_address_gen_0_ranges_1"] = 100
-    #new_config["strg_ub_output_addr_ctrl_address_gen_0_strides_1"] = 0
+    # new_config["strg_ub_output_addr_ctrl_address_gen_0_dimensionality"] = 2
+    # new_config["strg_ub_output_addr_ctrl_address_gen_0_starting_addr"] = 0
+    # new_config["strg_ub_output_addr_ctrl_address_gen_0_ranges_0"] = 16
+    # new_config["strg_ub_output_addr_ctrl_address_gen_0_strides_0"] = 1
+    # new_config["strg_ub_output_addr_ctrl_address_gen_0_ranges_1"] = 100
+    # new_config["strg_ub_output_addr_ctrl_address_gen_0_strides_1"] = 0
 
-    #new_config["strg_ub_output_addr_ctrl_address_gen_1_dimensionality"] = 2
-    #new_config["strg_ub_output_addr_ctrl_address_gen_1_starting_addr"] = 16
-    #new_config["strg_ub_output_addr_ctrl_address_gen_1_ranges_0"] = 16
-    #new_config["strg_ub_output_addr_ctrl_address_gen_1_strides_0"] = 1
-    #new_config["strg_ub_output_addr_ctrl_address_gen_1_ranges_1"] = 100
-    #new_config["strg_ub_output_addr_ctrl_address_gen_1_strides_1"] = 0
+    # new_config["strg_ub_output_addr_ctrl_address_gen_1_dimensionality"] = 2
+    # new_config["strg_ub_output_addr_ctrl_address_gen_1_starting_addr"] = 16
+    # new_config["strg_ub_output_addr_ctrl_address_gen_1_ranges_0"] = 16
+    # new_config["strg_ub_output_addr_ctrl_address_gen_1_strides_0"] = 1
+    # new_config["strg_ub_output_addr_ctrl_address_gen_1_ranges_1"] = 100
+    # new_config["strg_ub_output_addr_ctrl_address_gen_1_strides_1"] = 0
 
     # These ports are desynched
     # new_config["strg_ub_sync_grp_sync_group_0"] = 1  # not needed
     # new_config["strg_ub_sync_grp_sync_group_1"] = 2  # not needed
 
-    #new_config["strg_ub_app_ctrl_read_depth_0"] = 16
-    #new_config["strg_ub_app_ctrl_read_depth_1"] = 16
+    # new_config["strg_ub_app_ctrl_read_depth_0"] = 16
+    # new_config["strg_ub_app_ctrl_read_depth_1"] = 16
 
-    #new_config["strg_ub_app_ctrl_write_depth_0"] = 16
-    #new_config["strg_ub_app_ctrl_write_depth_1"] = 16
+    # new_config["strg_ub_app_ctrl_write_depth_0"] = 16
+    # new_config["strg_ub_app_ctrl_write_depth_1"] = 16
 
-    #new_config["strg_ub_app_ctrl_coarse_read_depth_0"] = 16
-    #new_config["strg_ub_app_ctrl_coarse_read_depth_1"] = 0
+    # new_config["strg_ub_app_ctrl_coarse_read_depth_0"] = 16
+    # new_config["strg_ub_app_ctrl_coarse_read_depth_1"] = 0
 
-    #new_config["strg_ub_app_ctrl_coarse_write_depth_0"] = 16
-    #new_config["strg_ub_app_ctrl_coarse_write_depth_1"] = 16
+    # new_config["strg_ub_app_ctrl_coarse_write_depth_0"] = 16
+    # new_config["strg_ub_app_ctrl_coarse_write_depth_1"] = 16
 
-    #new_config["strg_ub_app_ctrl_write_depth_ss_0"] = 16
-    #new_config["strg_ub_app_ctrl_write_depth_ss_0"] = 16
+    # new_config["strg_ub_app_ctrl_write_depth_ss_0"] = 16
+    # new_config["strg_ub_app_ctrl_write_depth_ss_0"] = 16
 
     # Don't use the model - this is handwritten for now
 

--- a/tests/test_pond_rd_wr.py
+++ b/tests/test_pond_rd_wr.py
@@ -1,0 +1,85 @@
+from lake.top.lake_top import LakeTop
+from lake.top.pond import Pond
+import kratos as kts
+import fault
+import random as rand
+import pytest
+import tempfile
+from lake.models.lake_top_model import LakeTopModel
+from lake.utils.util import transform_strides_and_ranges, generate_pond_api
+
+def test_pond(data_width=16,  # CGRA Params
+              mem_depth=32,
+              default_iterator_support=2,
+              config_data_width=32,
+              config_addr_width=8,
+              cycle_count_width=16,
+              add_clk_enable=True,
+              add_flush=True,
+              interconnect_input_ports=1,  # Connection to int
+              interconnect_output_ports=1):
+
+  
+    ### DUT
+    pond_dut = Pond(data_width=data_width,  # CGRA Params
+                    mem_depth=mem_depth,
+                    default_iterator_support=default_iterator_support,
+                    interconnect_input_ports=interconnect_input_ports,  # Connection to int
+                    interconnect_output_ports=interconnect_output_ports,
+                    config_data_width=config_data_width,
+                    config_addr_width=config_addr_width,
+                    cycle_count_width=cycle_count_width,
+                    add_clk_enable=add_clk_enable,
+                    add_flush=add_flush)
+
+    magma_dut = kts.util.to_magma(pond_dut,
+                                  flatten_array=True,
+                                  check_multiple_driver=False,
+                                  optimize_if=False,
+                                  check_flip_flop_always_ff=False)
+
+    tester = fault.Tester(magma_dut, magma_dut.clk)
+    ###
+    # Ranges, Strides, Dimensionality, Starting Addr, Starting Addr - Schedule
+    ctrl_rd = [[16, 1], [1, 1], 2, 0, 16]
+    ctrl_wr = [[16, 1], [1, 1], 2, 0, 0]
+    pond_config = generate_pond_api(ctrl_rd, ctrl_wr)
+
+    for key, value in pond_config.items():
+        setattr(tester.circuit, key, value)
+
+    rand.seed(0)
+    tester.circuit.clk = 0
+    tester.circuit.clk_en = 1
+    tester.circuit.tile_en = 1
+    tester.circuit.rst_n = 0
+    tester.step(2)
+    tester.circuit.rst_n = 1
+    tester.step(2)
+    tester.circuit.clk_en = 1
+
+    data_in_pond = [0] * interconnect_input_ports
+    valid_in = [0] * interconnect_input_ports
+    for i in range(32):
+        # Incrementing Data
+        data_in_pond[0] = data_in_pond[0] + 1
+
+
+        if interconnect_input_ports == 1:
+            tester.circuit.data_in_pond = data_in_pond[0]
+        else:
+            for j in range(interconnect_input_ports):
+                setattr(tester.circuit, f"data_in_{j}", data_in_pond[j])
+        tester.eval()
+        tester.step(2)
+
+    with tempfile.TemporaryDirectory() as tempdir:
+        tempdir = "dump"
+        tester.compile_and_run(target="verilator",
+                               directory=tempdir,
+                               magma_output="verilog",
+                               flags=["-Wno-fatal", "--trace"])
+
+
+if __name__ == "__main__":
+    test_pond()

--- a/tests/test_pond_rd_wr.py
+++ b/tests/test_pond_rd_wr.py
@@ -8,6 +8,7 @@ import tempfile
 from lake.models.lake_top_model import LakeTopModel
 from lake.utils.util import transform_strides_and_ranges, generate_pond_api
 
+
 def test_pond(data_width=16,  # CGRA Params
               mem_depth=32,
               default_iterator_support=2,
@@ -19,7 +20,6 @@ def test_pond(data_width=16,  # CGRA Params
               interconnect_input_ports=1,  # Connection to int
               interconnect_output_ports=1):
 
-  
     ### DUT
     pond_dut = Pond(data_width=data_width,  # CGRA Params
                     mem_depth=mem_depth,
@@ -69,10 +69,10 @@ def test_pond(data_width=16,  # CGRA Params
         else:
             for j in range(interconnect_input_ports):
                 setattr(tester.circuit, f"data_in_{j}", data_in_pond[j])
-        
+
         if i >= 16:
-            tester.circuit.data_out_pond.expect(i-15)
-   
+            tester.circuit.data_out_pond.expect(i - 15)
+
         tester.eval()
         tester.step(2)
 

--- a/tests/test_pond_rd_wr.py
+++ b/tests/test_pond_rd_wr.py
@@ -63,13 +63,20 @@ def test_pond(data_width=16,  # CGRA Params
     for i in range(32):
         # Incrementing Data
         data_in_pond[0] = data_in_pond[0] + 1
-
+        #data_in_pond[0] = 2 
 
         if interconnect_input_ports == 1:
             tester.circuit.data_in_pond = data_in_pond[0]
         else:
             for j in range(interconnect_input_ports):
                 setattr(tester.circuit, f"data_in_{j}", data_in_pond[j])
+        
+        if i >= 15 and i < 31:
+            tester.circuit.data_out_pond.expect(i-15)
+
+        if i >= 16:
+            tester.circuit.data_out_pond.expect(i-16)
+   
         tester.eval()
         tester.step(2)
 

--- a/tests/test_pond_rd_wr.py
+++ b/tests/test_pond_rd_wr.py
@@ -53,9 +53,9 @@ def test_pond(data_width=16,  # CGRA Params
     tester.circuit.clk_en = 1
     tester.circuit.tile_en = 1
     tester.circuit.rst_n = 0
-    tester.step(2)
+    tester.step(1)
     tester.circuit.rst_n = 1
-    tester.step(2)
+    tester.step(1)
     tester.circuit.clk_en = 1
 
     data_in_pond = [0] * interconnect_input_ports
@@ -63,7 +63,6 @@ def test_pond(data_width=16,  # CGRA Params
     for i in range(32):
         # Incrementing Data
         data_in_pond[0] = data_in_pond[0] + 1
-        #data_in_pond[0] = 2 
 
         if interconnect_input_ports == 1:
             tester.circuit.data_in_pond = data_in_pond[0]
@@ -71,17 +70,13 @@ def test_pond(data_width=16,  # CGRA Params
             for j in range(interconnect_input_ports):
                 setattr(tester.circuit, f"data_in_{j}", data_in_pond[j])
         
-        if i >= 15 and i < 31:
-            tester.circuit.data_out_pond.expect(i-15)
-
         if i >= 16:
-            tester.circuit.data_out_pond.expect(i-16)
+            tester.circuit.data_out_pond.expect(i-15)
    
         tester.eval()
         tester.step(2)
 
     with tempfile.TemporaryDirectory() as tempdir:
-        tempdir = "dump"
         tester.compile_and_run(target="verilator",
                                directory=tempdir,
                                magma_output="verilog",


### PR DESCRIPTION
## Update Pond

This PR serves to bring the pond generated from this repo into the modern day.

This includes:

1. Isolated Pond generation at `lake/top/pond.py`:

Rather than trying to hack together the code for every odd parameterization we could think of in the LakeTop constructor (esp. with chaining being a real pain), it makes sense to have some separate base architectures to play with. This makes the code more readable and reusable, as design intent is clearer.

2. No chaining

Self-explanatory

3. New entry point for garnet

Garnet needs updates to use this new generation entry point for the Pond hardware - reunification pending if we can't easily wrap a tile around this separate entry.

4. Will eventually contain tests, courtesy of Ankita
