### PR TITLE
Automatically generate Lake wrapper with config regs set as constants for multi tile testing without garnet mapping

### DIFF
--- a/lake/utils/util.py
+++ b/lake/utils/util.py
@@ -151,6 +151,7 @@ def generate_lake_config_wrapper(configs_list, configs_file, lake_file):
                 start = True
             elif start and ");" in line:
                 start = False
+                break
             elif start:
                 add = 1
                 for config in configs_list:

--- a/lake/utils/util.py
+++ b/lake/utils/util.py
@@ -176,12 +176,18 @@ def generate_lake_config_wrapper(configs_list, configs_file, lake_file):
         # instantiate LakeTop_W module with
         # full interface, first with nonconfigs
         wrapper.write("LakeTop_W LakeTop_W (\n")
-        for not_config in not_configs:
+        for i in range(len(not_configs)):
+            not_config = not_configs[i]
             try_name = not_config.split("]")
             if len(try_name) == 1:
                 try_name = not_config.split("logic")
             name = try_name[1].split(",")[0]
-            wrapper.write(f".{name}({name}),\n")
+            # if there are no config regs, this is the last
+            # signal in the interface
+            if (i == len(not_configs) - 1) and (len(configs_list) == 0):
+                wrapper.write(f".{name}({name})\n);\n")
+            else:
+                wrapper.write(f".{name}({name}),\n")
 
         # hook up config regs for LakeTop_W as well
         for i in range(len(configs_list)):
@@ -192,7 +198,8 @@ def generate_lake_config_wrapper(configs_list, configs_file, lake_file):
                 wrapper.write(f".{config}({config}),\n")
 
         wrapper.write("endmodule\n\n")
-    # append wrapper module to original verilog file
+
+    # prepend wrapper module to original verilog file
     with open("LakeWrapper.v", "a") as wrapper:
         with open(lake_file, "r") as original:
             for line in original:

--- a/lake/utils/util.py
+++ b/lake/utils/util.py
@@ -190,6 +190,7 @@ def generate_lake_config_wrapper(configs_list, configs_file, lake_file):
             else:
                 wrapper.write(f".{config}({config}),\n")
 
+        wrapper.write("endmodule\n\n")
     # append wrapper module to original verilog file
     with open("LakeWrapper.v", "a") as wrapper:
         with open(lake_file, "r") as original:

--- a/lake/utils/util.py
+++ b/lake/utils/util.py
@@ -157,7 +157,7 @@ def generate_lake_config_wrapper(configs_list, configs_file, lake_file):
                     if config in line:
                         add = 0
                         break
-                if add == 1: 
+                if add == 1:
                     not_configs.append(line)
 
     # write top level interface (without config regs)
@@ -172,7 +172,7 @@ def generate_lake_config_wrapper(configs_list, configs_file, lake_file):
             for config in configs:
                 wrapper.write(config)
 
-        # instantiate LakeTop_W module with 
+        # instantiate LakeTop_W module with
         # full interface, first with nonconfigs
         wrapper.write("LakeTop_W LakeTop_W (\n")
         for not_config in not_configs:

--- a/lake/utils/util.py
+++ b/lake/utils/util.py
@@ -161,8 +161,9 @@ def generate_lake_config_wrapper(configs_list, configs_file, lake_file):
                 if add == 1:
                     not_configs.append(line)
 
-    # write top level interface (without config regs)
     with open("LakeWrapper.v", "w+") as wrapper:
+
+        # write top level interface (without config regs)
         wrapper.write("module LakeWrapper (\n")
         for not_config in not_configs:
             wrapper.write(not_config)

--- a/lake/utils/util.py
+++ b/lake/utils/util.py
@@ -183,6 +183,12 @@ def generate_lake_config_wrapper(configs_list, configs_file, lake_file):
             else:
                 wrapper.write(f".{config}({config}),\n")
 
+    
+    with open("LakeWrapper.v", "a") as wrapper:
+        with open(lake_file, "r") as original:
+            for line in original:
+                wrapper.write(line)
+
 def transform_strides_and_ranges(ranges, strides, dimensionality):
     assert len(ranges) == len(strides), "Strides and ranges should be same length..."
     tform_ranges = [range_item - 2 for range_item in ranges[0:dimensionality]]

--- a/tests/test_lake.py
+++ b/tests/test_lake.py
@@ -42,7 +42,6 @@ def base_lake(config_path,
 
 
 def get_lake_wrapper(config_path,
-                  stream_path,
                   in_file_name="input",
                   out_file_name="output",
                   in_ports=2,
@@ -120,11 +119,11 @@ def test_conv_3_3():
     config_path = lc + "conv_3_3_recipe/buf_inst_input_10_to_buf_inst_output_3_ubuf"
     stream_path = ls + "conv_3_3_recipe/buf_inst_input_10_to_buf_inst_output_3_ubuf_0_top_SMT.csv"
     
-    get_lake_wrapper(config_path=config_path,
-                  stream_path=stream_path)
+    get_lake_wrapper(config_path=config_path)
+                  # stream_path=stream_path)
 
-    gen_test_lake(config_path=config_path,
-                  stream_path=stream_path)
+    # gen_test_lake(config_path=config_path,
+    #               stream_path=stream_path)
 
     
 @pytest.mark.skip

--- a/tests/test_lake.py
+++ b/tests/test_lake.py
@@ -12,12 +12,11 @@ from lake.utils.parse_clkwork_csv import generate_data_lists
 # configurations
 from lake.utils.parse_clkwork_config import *
 from lake.utils.util import get_configs_dict, set_configs_sv
-from lake.utils.util import generate_lake_config_wrapper
 from lake.utils.util import extract_formal_annotation
 from lake.utils.util import check_env
 
 
-def base_lake(config_path,
+def base_lake_tester(config_path,
               in_file_name,
               out_file_name,
               in_ports,
@@ -41,26 +40,6 @@ def base_lake(config_path,
     return lt_dut, configs, configs_list, magma_dut, tester
 
 
-def get_lake_wrapper(config_path,
-                     in_file_name="input",
-                     out_file_name="output",
-                     in_ports=2,
-                     out_ports=2):
-
-    lt_dut, configs, configs_list, magma_dut, tester = \
-        base_lake(config_path,
-                  in_file_name,
-                  out_file_name,
-                  in_ports,
-                  out_ports)
-
-    with tempfile.TemporaryDirectory() as tempdir:
-        tester.compile_and_run(target="verilator",
-                               flags=["-Wno-fatal"])
-
-    generate_lake_config_wrapper(configs_list, "configs.sv", "build/LakeTop_W.v")
-
-
 def gen_test_lake(config_path,
                   stream_path,
                   in_file_name="input",
@@ -69,7 +48,7 @@ def gen_test_lake(config_path,
                   out_ports=2):
 
     lt_dut, configs, configs_list, magma_dut, tester = \
-        base_lake(config_path,
+        base_lake_tester(config_path,
                   in_file_name,
                   out_file_name,
                   in_ports,
@@ -119,13 +98,6 @@ def test_conv_3_3():
 
     gen_test_lake(config_path=config_path,
                   stream_path=stream_path)
-
-
-def wrapper_conv_3_3():
-    lc, ls = check_env()
-    config_path = lc + "conv_3_3_recipe/buf_inst_input_10_to_buf_inst_output_3_ubuf"
-
-    get_lake_wrapper(config_path=config_path)
 
 
 @pytest.mark.skip
@@ -218,7 +190,6 @@ if __name__ == "__main__":
 
     # conv_3_3
     test_conv_3_3()
-    wrapper_conv_3_3()
 
     # gaussian
     # test_gaussian()

--- a/tests/test_lake.py
+++ b/tests/test_lake.py
@@ -99,7 +99,7 @@ def gen_test_lake(config_path,
         tempdir="dump"
         tester.compile_and_run(target="verilator",
                                directory=tempdir,
-                               flags=["-Wno-fatal"])
+                               flags=["-Wno-fatal", "--trace"])
 
 
 def test_conv_3_3():
@@ -108,6 +108,9 @@ def test_conv_3_3():
     stream_path = ls + "conv_3_3_recipe/buf_inst_input_10_to_buf_inst_output_3_ubuf_0_top_SMT.csv"
     # gen_test_lake(config_path=config_path,
     get_lake_wrapper(config_path=config_path,
+                  stream_path=stream_path)
+
+    gen_test_lake(config_path=config_path,
                   stream_path=stream_path)
 
 

--- a/tests/test_lake.py
+++ b/tests/test_lake.py
@@ -11,16 +11,17 @@ from lake.utils.sram_macro import SRAMMacroInfo
 from lake.utils.parse_clkwork_csv import generate_data_lists
 # configurations
 from lake.utils.parse_clkwork_config import *
-from lake.utils.util import get_configs_dict, set_configs_sv, extract_formal_annotation, generate_lake_config_wrapper
+from lake.utils.util import get_configs_dict, set_configs_sv
+from lake.utils.util import generate_lake_config_wrapper
+from lake.utils.util import extract_formal_annotation
 from lake.utils.util import check_env
 
 
-def get_lake_wrapper(config_path,
-                  stream_path,
-                  in_file_name="input",
-                  out_file_name="output",
-                  in_ports=2,
-                  out_ports=2):
+def base_lake(config_path,
+              in_file_name,
+              out_file_name,
+              in_ports,
+              out_ports):
 
     lt_dut = LakeTop(interconnect_input_ports=in_ports,
                      interconnect_output_ports=out_ports,
@@ -34,13 +35,33 @@ def get_lake_wrapper(config_path,
                                   check_multiple_driver=False,
                                   optimize_if=False,
                                   check_flip_flop_always_ff=False)
-
+    
     tester = fault.Tester(magma_dut, magma_dut.clk)
+
+    return lt_dut, configs, configs_list, magma_dut, tester
+
+
+def get_lake_wrapper(config_path,
+                  stream_path,
+                  in_file_name="input",
+                  out_file_name="output",
+                  in_ports=2,
+                  out_ports=2):
+
+
+    lt_dut, configs, configs_list, magma_dut, tester = \
+        base_lake(config_path,
+                  in_file_name,
+                  out_file_name,
+                  in_ports,
+                  out_ports)
+
     with tempfile.TemporaryDirectory() as tempdir:
         tester.compile_and_run(target="verilator",
                                flags=["-Wno-fatal"])
 
     generate_lake_config_wrapper(configs_list, "configs.sv", "build/LakeTop_W.v")
+
 
 def gen_test_lake(config_path,
                   stream_path,
@@ -49,20 +70,12 @@ def gen_test_lake(config_path,
                   in_ports=2,
                   out_ports=2):
 
-    lt_dut = LakeTop(interconnect_input_ports=in_ports,
-                     interconnect_output_ports=out_ports,
-                     stencil_valid=False)
-
-    configs = lt_dut.get_static_bitstream(config_path, in_file_name, out_file_name)
-    set_configs_sv(lt_dut, "configs.sv", get_configs_dict(configs))
-
-    magma_dut = kts.util.to_magma(lt_dut,
-                                  flatten_array=True,
-                                  check_multiple_driver=False,
-                                  optimize_if=False,
-                                  check_flip_flop_always_ff=False)
-
-    tester = fault.Tester(magma_dut, magma_dut.clk)
+    lt_dut, configs, configs_list, magma_dut, tester = \
+        base_lake(config_path,
+                  in_file_name,
+                  out_file_name,
+                  in_ports,
+                  out_ports)
 
     tester.circuit.clk = 0
     tester.circuit.rst_n = 0
@@ -106,14 +119,14 @@ def test_conv_3_3():
     lc, ls = check_env()
     config_path = lc + "conv_3_3_recipe/buf_inst_input_10_to_buf_inst_output_3_ubuf"
     stream_path = ls + "conv_3_3_recipe/buf_inst_input_10_to_buf_inst_output_3_ubuf_0_top_SMT.csv"
-    # gen_test_lake(config_path=config_path,
+    
     get_lake_wrapper(config_path=config_path,
                   stream_path=stream_path)
 
     gen_test_lake(config_path=config_path,
                   stream_path=stream_path)
 
-
+    
 @pytest.mark.skip
 def test_gaussian():
     lc, ls = check_env()

--- a/tests/test_lake.py
+++ b/tests/test_lake.py
@@ -17,10 +17,10 @@ from lake.utils.util import check_env
 
 
 def base_lake_tester(config_path,
-              in_file_name,
-              out_file_name,
-              in_ports,
-              out_ports):
+                     in_file_name,
+                     out_file_name,
+                     in_ports,
+                     out_ports):
 
     lt_dut = LakeTop(interconnect_input_ports=in_ports,
                      interconnect_output_ports=out_ports,
@@ -49,10 +49,10 @@ def gen_test_lake(config_path,
 
     lt_dut, configs, configs_list, magma_dut, tester = \
         base_lake_tester(config_path,
-                  in_file_name,
-                  out_file_name,
-                  in_ports,
-                  out_ports)
+                         in_file_name,
+                         out_file_name,
+                         in_ports,
+                         out_ports)
 
     tester.circuit.clk = 0
     tester.circuit.rst_n = 0

--- a/tests/test_lake.py
+++ b/tests/test_lake.py
@@ -20,11 +20,12 @@ def base_lake_tester(config_path,
                      in_file_name,
                      out_file_name,
                      in_ports,
-                     out_ports):
+                     out_ports,
+                     stencil_valid=False):
 
     lt_dut = LakeTop(interconnect_input_ports=in_ports,
                      interconnect_output_ports=out_ports,
-                     stencil_valid=False)
+                     stencil_valid=stencil_valid)
 
     configs = lt_dut.get_static_bitstream(config_path, in_file_name, out_file_name)
     configs_list = set_configs_sv(lt_dut, "configs.sv", get_configs_dict(configs))

--- a/tests/test_lake.py
+++ b/tests/test_lake.py
@@ -124,7 +124,6 @@ def test_conv_3_3():
 def wrapper_conv_3_3():
     lc, ls = check_env()
     config_path = lc + "conv_3_3_recipe/buf_inst_input_10_to_buf_inst_output_3_ubuf"
-    stream_path = ls + "conv_3_3_recipe/buf_inst_input_10_to_buf_inst_output_3_ubuf_0_top_SMT.csv"
 
     get_lake_wrapper(config_path=config_path)
 

--- a/tests/test_lake.py
+++ b/tests/test_lake.py
@@ -35,18 +35,17 @@ def base_lake(config_path,
                                   check_multiple_driver=False,
                                   optimize_if=False,
                                   check_flip_flop_always_ff=False)
-    
+
     tester = fault.Tester(magma_dut, magma_dut.clk)
 
     return lt_dut, configs, configs_list, magma_dut, tester
 
 
 def get_lake_wrapper(config_path,
-                  in_file_name="input",
-                  out_file_name="output",
-                  in_ports=2,
-                  out_ports=2):
-
+                     in_file_name="input",
+                     out_file_name="output",
+                     in_ports=2,
+                     out_ports=2):
 
     lt_dut, configs, configs_list, magma_dut, tester = \
         base_lake(config_path,
@@ -108,24 +107,28 @@ def gen_test_lake(config_path,
         tester.step(2)
 
     with tempfile.TemporaryDirectory() as tempdir:
-        tempdir="dump"
         tester.compile_and_run(target="verilator",
                                directory=tempdir,
-                               flags=["-Wno-fatal", "--trace"])
+                               flags=["-Wno-fatal"])
 
 
 def test_conv_3_3():
     lc, ls = check_env()
     config_path = lc + "conv_3_3_recipe/buf_inst_input_10_to_buf_inst_output_3_ubuf"
     stream_path = ls + "conv_3_3_recipe/buf_inst_input_10_to_buf_inst_output_3_ubuf_0_top_SMT.csv"
-    
+
+    gen_test_lake(config_path=config_path,
+                  stream_path=stream_path)
+
+
+def wrapper_conv_3_3():
+    lc, ls = check_env()
+    config_path = lc + "conv_3_3_recipe/buf_inst_input_10_to_buf_inst_output_3_ubuf"
+    stream_path = ls + "conv_3_3_recipe/buf_inst_input_10_to_buf_inst_output_3_ubuf_0_top_SMT.csv"
+
     get_lake_wrapper(config_path=config_path)
-                  # stream_path=stream_path)
 
-    # gen_test_lake(config_path=config_path,
-    #               stream_path=stream_path)
 
-    
 @pytest.mark.skip
 def test_gaussian():
     lc, ls = check_env()
@@ -216,6 +219,7 @@ if __name__ == "__main__":
 
     # conv_3_3
     test_conv_3_3()
+    wrapper_conv_3_3()
 
     # gaussian
     # test_gaussian()

--- a/tests/wrapper_lake.py
+++ b/tests/wrapper_lake.py
@@ -55,3 +55,6 @@ def main(argv):
 
 if __name__ == "__main__":
     main(sys.argv[1:])
+
+    # Example usage:
+    # python tests/wrapper_lake.py -c conv_3_3_recipe/buf_inst_input_10_to_buf_inst_output_3_ubuf

--- a/tests/wrapper_lake.py
+++ b/tests/wrapper_lake.py
@@ -33,24 +33,27 @@ def wrapper(config_path_input):
     get_lake_wrapper(config_path=config_path)
 
 
+def error(usage):
+    print(usage)
+    sys.exit(2)
+
+
 def main(argv):
     usage = "File usage: python wrapper.py -c [csv_file path relative to LAKE_CONTROLLERS environment variable]"
     try:
         options, remainder = getopt.getopt(argv, 'c:', ["csv_file="])
     except getopt.GetoptError as e:
-        print(usage)
-        sys.exit(2)
+        error(usage)
 
     if len(options) != 1:
-        print(usage)
-        sys.exit(2)
+        error(usage)
 
     for opt, arg in options:
         if opt in ("-c", "--csv_file"):
             wrapper(arg)
         else:
             print("Invalid command line argument.")
-            sys.exit(2)
+            error(usage)
 
 
 if __name__ == "__main__":

--- a/tests/wrapper_lake.py
+++ b/tests/wrapper_lake.py
@@ -63,7 +63,7 @@ def main(argv):
             elif arg == "True":
                 stencil_valid = True
             else:
-                print("Invalid option for stencil valid...defaulting to True")
+                print("Invalid option for stencil valid (must be True or False)...defaulting to True")
         else:
             print("Invalid command line argument.")
             error(usage)

--- a/tests/wrapper_lake.py
+++ b/tests/wrapper_lake.py
@@ -15,10 +15,10 @@ def get_lake_wrapper(config_path,
 
     lt_dut, configs, configs_list, magma_dut, tester = \
         base_lake_tester(config_path,
-                  in_file_name,
-                  out_file_name,
-                  in_ports,
-                  out_ports)
+                         in_file_name,
+                         out_file_name,
+                         in_ports,
+                         out_ports)
 
     with tempfile.TemporaryDirectory() as tempdir:
         tester.compile_and_run(target="verilator",

--- a/tests/wrapper_lake.py
+++ b/tests/wrapper_lake.py
@@ -1,8 +1,10 @@
+import getopt
+import sys
 import tempfile
 
 from lake.utils.util import generate_lake_config_wrapper
 from lake.utils.util import check_env
-from test_lake import base_lake
+from test_lake import base_lake_tester
 
 
 def get_lake_wrapper(config_path,
@@ -12,7 +14,7 @@ def get_lake_wrapper(config_path,
                      out_ports=2):
 
     lt_dut, configs, configs_list, magma_dut, tester = \
-        base_lake(config_path,
+        base_lake_tester(config_path,
                   in_file_name,
                   out_file_name,
                   in_ports,
@@ -25,13 +27,26 @@ def get_lake_wrapper(config_path,
     generate_lake_config_wrapper(configs_list, "configs.sv", "build/LakeTop_W.v")
 
 
-def wrapper():
+def wrapper(config_path_input):
     lc, ls = check_env()
-    config_path = lc + "conv_3_3_recipe/buf_inst_input_10_to_buf_inst_output_3_ubuf"
-
+    config_path = lc + config_path_input
     get_lake_wrapper(config_path=config_path)
 
 
-#def main():
+def main(argv):
+    try:
+        options, remainder = getopt.getopt(argv, 'c:', ["csv_file="])
+    except getopt.GetoptError as e:
+        print("File usage: python wrapper.py -c [csv_file path relative to LAKE_CONTROLLER environment variable]")
+        sys.exit(2)
+
+    for opt, arg in options:
+        if opt in ("-c", "--csv_file"):
+            wrapper(arg)
+        else:
+            print("Invalid command line argument.")
+            sys.exit(2)
+
+
 if __name__ == "__main__":
-    wrapper()
+    main(sys.argv[1:])

--- a/tests/wrapper_lake.py
+++ b/tests/wrapper_lake.py
@@ -1,0 +1,37 @@
+import tempfile
+
+from lake.utils.util import generate_lake_config_wrapper
+from lake.utils.util import check_env
+from test_lake import base_lake
+
+
+def get_lake_wrapper(config_path,
+                     in_file_name="input",
+                     out_file_name="output",
+                     in_ports=2,
+                     out_ports=2):
+
+    lt_dut, configs, configs_list, magma_dut, tester = \
+        base_lake(config_path,
+                  in_file_name,
+                  out_file_name,
+                  in_ports,
+                  out_ports)
+
+    with tempfile.TemporaryDirectory() as tempdir:
+        tester.compile_and_run(target="verilator",
+                               flags=["-Wno-fatal"])
+
+    generate_lake_config_wrapper(configs_list, "configs.sv", "build/LakeTop_W.v")
+
+
+def wrapper():
+    lc, ls = check_env()
+    config_path = lc + "conv_3_3_recipe/buf_inst_input_10_to_buf_inst_output_3_ubuf"
+
+    get_lake_wrapper(config_path=config_path)
+
+
+#def main():
+if __name__ == "__main__":
+    wrapper()

--- a/tests/wrapper_lake.py
+++ b/tests/wrapper_lake.py
@@ -34,10 +34,15 @@ def wrapper(config_path_input):
 
 
 def main(argv):
+    usage = "File usage: python wrapper.py -c [csv_file path relative to LAKE_CONTROLLERS environment variable]"
     try:
         options, remainder = getopt.getopt(argv, 'c:', ["csv_file="])
     except getopt.GetoptError as e:
-        print("File usage: python wrapper.py -c [csv_file path relative to LAKE_CONTROLLER environment variable]")
+        print(usage)
+        sys.exit(2)
+
+    if len(options) != 1:
+        print(usage)
         sys.exit(2)
 
     for opt, arg in options:

--- a/tests/wrapper_lake.py
+++ b/tests/wrapper_lake.py
@@ -18,7 +18,8 @@ def get_lake_wrapper(config_path,
                          in_file_name,
                          out_file_name,
                          in_ports,
-                         out_ports)
+                         out_ports,
+                         True)
 
     with tempfile.TemporaryDirectory() as tempdir:
         tester.compile_and_run(target="verilator",

--- a/tests/wrapper_tb.sv
+++ b/tests/wrapper_tb.sv
@@ -18,6 +18,7 @@ module TB;
     reg [31:0] config0;
     reg [31:0] config1;
     reg [2:0] test;
+    reg [0:0] stencil_valid;
 
     LakeWrapper DUT (
         .addr_in_0(0),
@@ -45,6 +46,7 @@ module TB;
         .empty(empty),
         .full(full),
         .sram_ready_out(read_out),
+        .stencil_valid(stencil_valid),
         .valid_out(valid_out)
     );
 

--- a/tests/wrapper_tb.sv
+++ b/tests/wrapper_tb.sv
@@ -18,7 +18,7 @@ module TB;
     reg [31:0] config0;
     reg [31:0] config1;
     reg [2:0] test;
-    reg [0:0] stencil_valid;
+    // reg [0:0] stencil_valid;
 
     LakeWrapper DUT (
         .addr_in_0(0),
@@ -46,7 +46,7 @@ module TB;
         .empty(empty),
         .full(full),
         .sram_ready_out(read_out),
-        .stencil_valid(stencil_valid),
+        // .stencil_valid(stencil_valid),
         .valid_out(valid_out)
     );
 

--- a/tests/wrapper_tb.sv
+++ b/tests/wrapper_tb.sv
@@ -1,0 +1,85 @@
+`define CLK_PERIOD 1.1
+`define CLK_PERIOD 1.1
+`define ASSIGNMENT_DELAY 0.22000000000000003
+`define CONFIG_TIME 4096
+`define RUN_TIME 406900
+
+module TB;
+
+    reg [0:0] clk;
+    reg [15:0] data_in_0;
+    reg [0:0] rst_n;
+    reg [15:0] data_out_0;
+    reg [15:0] data_out_1;
+    reg [0:0] empty;
+    reg [0:0] full;
+    reg [1:0] read_out;
+    reg [1:0] valid_out;
+    reg [31:0] config0;
+    reg [31:0] config1;
+    reg [2:0] test;
+
+    LakeWrapper DUT (
+        .addr_in_0(0),
+        .addr_in_1(0),
+        .chain_data_in_0(0),
+        .chain_data_in_1(0),
+        .clk(clk),
+        .clk_en(1),
+        .config_addr_in(0),
+        .config_data_in(0),
+        .config_en(0),
+        .config_read(0),
+        .config_write(0),
+        .data_in_0(data_in_0),
+        .data_in_1(0),
+        .fifo_ctrl_fifo_depth(0),
+        .flush(0),
+        .ren_in(0),
+        .rst_n(rst_n),
+        .wen_in(0),
+        .config_data_out_0(config0),
+        .config_data_out_1(config1),
+        .data_out_0(data_out_0),
+        .data_out_1(data_out_1),
+        .empty(empty),
+        .full(full),
+        .sram_ready_out(read_out),
+        .valid_out(valid_out)
+    );
+
+    always #(`CLK_PERIOD/2) clk =~clk;
+
+    always @ (posedge clk) begin
+        if (test < 2) begin
+            test += 1;
+            rst_n = 0;
+            data_in_0 = 0;
+        end else begin
+            test = 2;
+            rst_n = 1;
+            data_in_0 = data_in_0 + 1;
+        end
+    end
+
+    initial begin
+      clk <= 0;
+      data_in_0 = 0;
+      test = 0;
+      rst_n <= 0;
+    end
+  
+    initial begin
+      $vcdplusfile("dump.vpd");
+      $vcdplusmemon();
+      $vcdpluson(0, TB);
+      $set_toggle_region(TB);
+      #(`CONFIG_TIME);
+      $toggle_start();
+      #(`RUN_TIME);
+      $toggle_stop();
+      $toggle_report("outputs/run.saif", 1e-9, TB);
+      $finish(2);
+    end
+
+endmodule


### PR DESCRIPTION
This PR enables automatically generating Verilog consisting of the memory core as well as a wrapper that has the same interface minus the config regs (output: LakeWrapper.v with top level module LakeWrapper). This wrapper automatically sets the (translated if needed) config reg values for the memory core hardware given a Clockwork config reg csv, enabling the compiler team to do multi tile tests without having to map the config regs through garnet.

Example usage for conv_3_3_recipe config regs:
python tests/wrapper_lake.py -c conv_3_3_recipe/buf_inst_input_10_to_buf_inst_output_3_ubuf

-c or --csv_file specifies path to csv file relative to LAKE_CONTROLLERS env var
-s or --stencil_valid specifies whether or not to include stencil_valid in Lake interface with True or False (default value: True)

This PR also includes a Verilog testbench to debug LakeWrapper.v syntax and data output accuracy after the wrapper is added to the core verilog as well as an example of the module/interface the compiler team would need to stamp out in their files.