### PR TITLE
one shot for all sched gens

### DIFF
--- a/lake/modules/spec/agg_formal.py
+++ b/lake/modules/spec/agg_formal.py
@@ -134,6 +134,7 @@ class AggFormal(Generator):
                            clk=self._clk,
                            rst_n=self._rst_n,
                            mux_sel=forloop_ctr.ports.mux_sel_out,
+                           finished=forloop_ctr.ports.restart,
                            cycle_count=self._cycle_count,
                            valid_output=self._agg_write[i])
 
@@ -212,6 +213,7 @@ class AggFormal(Generator):
                        rst_n=self._rst_n,
                        cycle_count=self._cycle_count,
                        mux_sel=output_loops.ports.mux_sel_out,
+                       finished=output_loops.ports.restart,
                        valid_output=self._write)
 
         for idx in range(self.interconnect_input_ports):

--- a/lake/modules/spec/sched_gen.py
+++ b/lake/modules/spec/sched_gen.py
@@ -37,16 +37,18 @@ class SchedGen(Generator):
         # Receive signal on last iteration of looping structure and
         # gate the output...
         self._finished = self.input("finished", 1)
+        self._valid_gate_inv = self.var("valid_gate_inv", 1)
         self._valid_gate = self.var("valid_gate", 1)
+        self.wire(self._valid_gate, ~self._valid_gate_inv)
 
         @always_ff((posedge, "clk"), (negedge, "rst_n"))
-        def valid_gate_ff():
+        def valid_gate_inv_ff():
             if ~self._rst_n:
-                self._valid_gate = 1
+                self._valid_gate_inv = 0
             # If we are finishing the looping structure, turn this off to implement one-shot
             elif self._finished:
-                self._valid_gate = 0
-        self.add_code(valid_gate_ff)
+                self._valid_gate_inv = 1
+        self.add_code(valid_gate_inv_ff)
 
         # Compare based on minimum of addr + global cycle...
         self.c_a_cmp = min(self._cycle_count.width, self._addr_out.width)

--- a/lake/modules/spec/sram_formal.py
+++ b/lake/modules/spec/sram_formal.py
@@ -117,6 +117,7 @@ class SRAMFormal(Generator):
                        rst_n=self._rst_n,
                        cycle_count=self._cycle_count,
                        mux_sel=fl_ctr_sram_wr.ports.mux_sel_out,
+                       finished=fl_ctr_sram_wr.ports.restart,
                        valid_output=self._write)
 
         # -------------------------------- Delineate new group -------------------------------
@@ -177,6 +178,7 @@ class SRAMFormal(Generator):
                        rst_n=self._rst_n,
                        cycle_count=self._cycle_count,
                        mux_sel=fl_ctr_sram_rd.ports.mux_sel_out,
+                       finished=fl_ctr_sram_rd.ports.restart,
                        valid_output=self._read)
 
         self.add_code(self.set_sram_addr)

--- a/lake/modules/spec/tb_formal.py
+++ b/lake/modules/spec/tb_formal.py
@@ -118,6 +118,7 @@ class TBFormal(Generator):
                        rst_n=self._rst_n,
                        cycle_count=self._cycle_count,
                        mux_sel=fl_ctr_sram_rd.ports.mux_sel_out,
+                       finished=fl_ctr_sram_rd.ports.restart,
                        valid_output=self._read)
 
         for i in range(self.interconnect_output_ports):
@@ -180,6 +181,7 @@ class TBFormal(Generator):
                            rst_n=self._rst_n,
                            cycle_count=self._cycle_count,
                            mux_sel=fl_ctr_tb_rd.ports.mux_sel_out,
+                           finished=fl_ctr_tb_rd.ports.restart,
                            valid_output=self._tb_read[i])
 
         if self.interconnect_output_ports > 1:

--- a/lake/modules/strg_ub_thin.py
+++ b/lake/modules/strg_ub_thin.py
@@ -150,6 +150,7 @@ class StrgUBThin(Generator):
                        rst_n=self._rst_n,
                        cycle_count=self._cycle_count,
                        mux_sel=fl_ctr_sram_wr.ports.mux_sel_out,
+                       finished=fl_ctr_sram_wr.ports.restart,
                        valid_output=self._write)
 
         # -------------------------------- Delineate new group -------------------------------
@@ -181,6 +182,7 @@ class StrgUBThin(Generator):
                        rst_n=self._rst_n,
                        cycle_count=self._cycle_count,
                        mux_sel=fl_ctr_sram_rd.ports.mux_sel_out,
+                       finished=fl_ctr_sram_rd.ports.restart,
                        valid_output=self._read)
 
         # Now deal with dual_port/single_port madness...

--- a/lake/modules/strg_ub_vec.py
+++ b/lake/modules/strg_ub_vec.py
@@ -205,6 +205,7 @@ class StrgUBVec(Generator):
                            clk=self._clk,
                            rst_n=self._rst_n,
                            mux_sel=forloop_ctr.ports.mux_sel_out,
+                           finished=forloop_ctr.ports.restart,
                            cycle_count=self._cycle_count,
                            valid_output=self._agg_write[i])
 
@@ -268,6 +269,7 @@ class StrgUBVec(Generator):
                        rst_n=self._rst_n,
                        cycle_count=self._cycle_count,
                        mux_sel=fl_ctr_sram_wr.ports.mux_sel_out,
+                       finished=fl_ctr_sram_wr.ports.restart,
                        valid_output=self._write)
 
         # -------------------------------- Delineate new group -------------------------------
@@ -291,6 +293,7 @@ class StrgUBVec(Generator):
                        rst_n=self._rst_n,
                        cycle_count=self._cycle_count,
                        mux_sel=self.loops_sram2tb.ports.mux_sel_out,
+                       finished=self.loops_sram2tb.ports.restart,
                        valid_output=self._read)
 
         self._tb_read = self.var("tb_read", self.interconnect_output_ports)
@@ -365,6 +368,7 @@ class StrgUBVec(Generator):
                            rst_n=self._rst_n,
                            cycle_count=self._cycle_count,
                            mux_sel=fl_ctr_tb_rd.ports.mux_sel_out,
+                           finished=fl_ctr_tb_rd.ports.restart,
                            valid_output=self._tb_read[i])
 
         if self.interconnect_output_ports > 1:

--- a/lake/top/lake_top.py
+++ b/lake/top/lake_top.py
@@ -157,21 +157,21 @@ class LakeTop(Generator):
             self._stencil_valid_int = self.var("stencil_valid_internal", 1)
 
             # Define config regs to count number of stencil_valids...
-            self._use_stencil_valid = add_config_reg(self, "use_stencil_valid", "use stencil valid...", 1)
-            self._num_stencil_valids = add_config_reg(self, "num_stencil_valids", "number of stencil valids until done...", 16)
-            self._stcl_vs = add_counter(self, "num_stcl_valid", 16, increment=self._use_stencil_valid & self._stencil_valid_int)
+            # self._use_stencil_valid = add_config_reg(self, "use_stencil_valid", "use stencil valid...", 1)
+            # self._num_stencil_valids = add_config_reg(self, "num_stencil_valids", "number of stencil valids until done...", 16)
+            # self._stcl_vs = add_counter(self, "num_stcl_valid", 16, increment=self._use_stencil_valid & self._stencil_valid_int)
 
-            self._stencil_valid_gate = self.var("stencil_valid_gate", 1)
+            # self._stencil_valid_gate = self.var("stencil_valid_gate", 1)
 
-            @always_ff((posedge, "clk"), (negedge, "rst_n"))
-            def stcl_valid_ff():
-                if ~self._rst_n:
-                    self._stencil_valid_gate = 1
-                # If the stencil valid is high and the count is correct, turn it to 0, we are done
-                elif self._stencil_valid_int & (self._stcl_vs == self._num_stencil_valids) & self._use_stencil_valid:
-                    self._stencil_valid_gate = 0
+            # @always_ff((posedge, "clk"), (negedge, "rst_n"))
+            # def stcl_valid_ff():
+            #     if ~self._rst_n:
+            #         self._stencil_valid_gate = 1
+            #     # If the stencil valid is high and the count is correct, turn it to 0, we are done
+            #     elif self._stencil_valid_int & (self._stcl_vs == self._num_stencil_valids) & self._use_stencil_valid:
+            #         self._stencil_valid_gate = 0
 
-            self.add_code(stcl_valid_ff)
+            # self.add_code(stcl_valid_ff)
 
             # Loop Iterators for stencil valid...
             self.add_child(f"loops_stencil_valid",
@@ -187,9 +187,11 @@ class LakeTop(Generator):
                            rst_n=self._rst_n,
                            cycle_count=self._cycle_count,
                            mux_sel=self._loops_stencil_valid.ports.mux_sel_out,
+                           finished=self._loops_stencil_valid.ports.restart,
                            valid_output=self._stencil_valid_int)
             # Wire out internal wire
-            self.wire(self._stencil_valid, self._stencil_valid_int & self._stencil_valid_gate & self._use_stencil_valid)
+            # self.wire(self._stencil_valid, self._stencil_valid_int & self._stencil_valid_gate & self._use_stencil_valid)
+            self.wire(self._stencil_valid, self._stencil_valid_int)
 
         self._config_addr_in = self.input("config_addr_in",
                                           self.config_addr_width)
@@ -931,12 +933,12 @@ class LakeTop(Generator):
 
         if "stencil_valid" in root_node:
             # We know we are using it now...
-            config.append((f"use_stencil_valid", 1))
-            if "num_valids" in root_node["stencil_valid"]:
-                num_valids = int(root_node["stencil_valid"]["num_valids"])
-            else:
-                num_valids = 65535
-            config.append((f"num_stencil_valids", num_valids - 1))
+            # config.append((f"use_stencil_valid", 1))
+            # if "num_valids" in root_node["stencil_valid"]:
+            #     num_valids = int(root_node["stencil_valid"]["num_valids"])
+            # else:
+            #     num_valids = 65535
+            # config.append((f"num_stencil_valids", num_valids - 1))
             stencil_valid = map_controller(extract_controller_json(root_node["stencil_valid"]), "stencil_valid")
 
             # Check actual stencil valid property of hardware before programming
@@ -1027,9 +1029,9 @@ class LakeTop(Generator):
             cfg_path = config_path + '/' + 'stencil_valid.csv'
             # Check if the stencil valid file exists...if it doesn't we just won't program it
             if os.path.exists(cfg_path):
-                config.append((f"use_stencil_valid", 1))
-                num_valids = 65535
-                config.append((f"num_stencil_valids", num_valids - 1))
+                # config.append((f"use_stencil_valid", 1))
+                # num_valids = 65535
+                # config.append((f"num_stencil_valids", num_valids - 1))
                 stcl_valid = map_controller(extract_controller(cfg_path), "stencil_valid")
                 config.append((f"loops_stencil_valid_dimensionality", stcl_valid.dim))
                 config.append((f"stencil_valid_sched_gen_sched_addr_gen_starting_addr", stcl_valid.cyc_strt))

--- a/lake/top/lake_top.py
+++ b/lake/top/lake_top.py
@@ -156,23 +156,6 @@ class LakeTop(Generator):
                                                 config_width=16)
             self._stencil_valid_int = self.var("stencil_valid_internal", 1)
 
-            # Define config regs to count number of stencil_valids...
-            # self._use_stencil_valid = add_config_reg(self, "use_stencil_valid", "use stencil valid...", 1)
-            # self._num_stencil_valids = add_config_reg(self, "num_stencil_valids", "number of stencil valids until done...", 16)
-            # self._stcl_vs = add_counter(self, "num_stcl_valid", 16, increment=self._use_stencil_valid & self._stencil_valid_int)
-
-            # self._stencil_valid_gate = self.var("stencil_valid_gate", 1)
-
-            # @always_ff((posedge, "clk"), (negedge, "rst_n"))
-            # def stcl_valid_ff():
-            #     if ~self._rst_n:
-            #         self._stencil_valid_gate = 1
-            #     # If the stencil valid is high and the count is correct, turn it to 0, we are done
-            #     elif self._stencil_valid_int & (self._stcl_vs == self._num_stencil_valids) & self._use_stencil_valid:
-            #         self._stencil_valid_gate = 0
-
-            # self.add_code(stcl_valid_ff)
-
             # Loop Iterators for stencil valid...
             self.add_child(f"loops_stencil_valid",
                            self._loops_stencil_valid,
@@ -932,15 +915,7 @@ class LakeTop(Generator):
                     config.append((f"strg_ub_tb_write_addr_gen_{tb}_strides_{i}", sram2tb.in_data_stride[i]))
 
         if "stencil_valid" in root_node:
-            # We know we are using it now...
-            # config.append((f"use_stencil_valid", 1))
-            # if "num_valids" in root_node["stencil_valid"]:
-            #     num_valids = int(root_node["stencil_valid"]["num_valids"])
-            # else:
-            #     num_valids = 65535
-            # config.append((f"num_stencil_valids", num_valids - 1))
             stencil_valid = map_controller(extract_controller_json(root_node["stencil_valid"]), "stencil_valid")
-
             # Check actual stencil valid property of hardware before programming
             if self.stencil_valid:
                 config.append((f"loops_stencil_valid_dimensionality", stencil_valid.dim))
@@ -1029,9 +1004,6 @@ class LakeTop(Generator):
             cfg_path = config_path + '/' + 'stencil_valid.csv'
             # Check if the stencil valid file exists...if it doesn't we just won't program it
             if os.path.exists(cfg_path):
-                # config.append((f"use_stencil_valid", 1))
-                # num_valids = 65535
-                # config.append((f"num_stencil_valids", num_valids - 1))
                 stcl_valid = map_controller(extract_controller(cfg_path), "stencil_valid")
                 config.append((f"loops_stencil_valid_dimensionality", stcl_valid.dim))
                 config.append((f"stencil_valid_sched_gen_sched_addr_gen_starting_addr", stcl_valid.cyc_strt))

--- a/lake/top/pond.py
+++ b/lake/top/pond.py
@@ -153,6 +153,7 @@ class Pond(Generator):
                            clk=self._gclk,
                            rst_n=self._rst_n,
                            mux_sel=RF_WRITE_ITER.ports.mux_sel_out,
+                           finished=RF_WRITE_ITER.ports.restart,
                            cycle_count=self._cycle_count,
                            valid_output=self._write[wr_port])
 
@@ -186,6 +187,7 @@ class Pond(Generator):
                            clk=self._gclk,
                            rst_n=self._rst_n,
                            mux_sel=RF_READ_ITER.ports.mux_sel_out,
+                           finished=RF_READ_ITER.ports.restart,
                            cycle_count=self._cycle_count,
                            valid_output=self._read[rd_port])
 


### PR DESCRIPTION
### One-Shot Schedule Generators

While I originally designed the schedule generators to keep running, there are non-deterministic timings at the interface with the global buffer, so letting cycle counts run out results in game-breaking overflows.  This prevents any of the hardware from continuing on after it has finished its prescribed set of loops.