### PR TITLE
add chain_en config reg

### DIFF
--- a/lake/modules/chain_accessor.py
+++ b/lake/modules/chain_accessor.py
@@ -1,4 +1,7 @@
 from kratos import *
+from lake.attributes.config_reg_attr import ConfigRegAttr
+from lake.attributes.formal_attr import FormalAttr, FormalSignalConstraint
+
 import kratos as kts
 
 
@@ -11,6 +14,11 @@ class ChainAccessor(Generator):
         # generator parameters
         self.data_width = data_width
         self.interconnect_output_ports = interconnect_output_ports
+
+        # chain enable configuration register
+        self._chain_en = self.input("chain_en", 1)
+        self._chain_en.add_attribute(ConfigRegAttr("Signal indicating whether to enable chaining"))
+        self._chain_en.add_attribute(FormalAttr(self._chain_en.name, FormalSignalConstraint.SET0))
 
         # inputs
         self._curr_tile_data_out = self.input("curr_tile_data_out",
@@ -42,7 +50,10 @@ class ChainAccessor(Generator):
             if self._accessor_output[i]:
                 self._data_out_tile[i] = self._curr_tile_data_out[i]
             else:
-                self._data_out_tile[i] = self._chain_data_in[i]
+                if self._chain_en:
+                    self._data_out_tile[i] = self._chain_data_in[i]
+                else:
+                    self._data_out_tile[i] = 0
 
 
 if __name__ == "__main__":

--- a/lake/top/lake_top.py
+++ b/lake/top/lake_top.py
@@ -94,7 +94,7 @@ class LakeTop(Generator):
         self._rst_n = self.reset("rst_n")
         self._rst_n.add_attribute(FormalAttr(self._rst_n.name, FormalSignalConstraint.RSTN))
 
-        # Chaining config regs
+        # chain data in
         self._chain_data_in = self.input("chain_data_in",
                                          self.data_width,
                                          size=self.interconnect_output_ports,
@@ -245,6 +245,7 @@ class LakeTop(Generator):
         self._tile_en = self.input("tile_en", 1)
         self._tile_en.add_attribute(ConfigRegAttr("Tile logic enable manifested as clock gate"))
         self._tile_en.add_attribute(FormalAttr(self._tile_en.name, FormalSignalConstraint.SET1))
+
         # either normal or fifo mode rn...
         self.num_modes = 3
         self._mode = self.input("mode", max(1, clog2(self.num_modes)))


### PR DESCRIPTION
For https://github.com/StanfordAHA/lake/issues/79: adds chaining enable config reg so that invalid chain_data_in does not propagate to output when chaining is not needed and data_out is not valid. Compiler team thinks it should be doable to generate this as part of their config reg csvs, but we may need to change this as we try tests utilizing chaining later on.