### PR TITLE
End boundary bug

### DIFF
--- a/lake/modules/for_loop.py
+++ b/lake/modules/for_loop.py
@@ -95,7 +95,7 @@ class ForLoop(Generator):
     @always_comb
     def set_clear(self, idx):
         self._clear[idx] = 0
-        if ((idx < self._mux_sel) & self._step) | (~self._done):
+        if ((idx < self._mux_sel) | (~self._done)) & self._step:
             self._clear[idx] = 1
 
     @always_comb

--- a/lake/modules/for_loop.py
+++ b/lake/modules/for_loop.py
@@ -79,7 +79,7 @@ class ForLoop(Generator):
         # GENERATION LOGIC: end
 
         self._restart = self.output("restart", 1)
-        self.wire(self._restart, ~self._done)
+        self.wire(self._restart, ~self._done & self._step)
 
     @always_comb
     # Find lowest ready


### PR DESCRIPTION
@Kuree We got a bug!

This PR fixes a bug which causes the hardware looping structures to miss/skip their last action when the increment to the schedule generator != 1. This was exposed by removing the outermost redundant loop from the configuration. Stencil valids had typically back-to-back valids, so this wasn't exposed when we removed the outermost loop for those.