### PR TITLE
reorder statement to save codegen

### DIFF
--- a/lake/modules/for_loop.py
+++ b/lake/modules/for_loop.py
@@ -79,7 +79,7 @@ class ForLoop(Generator):
         # GENERATION LOGIC: end
 
         self._restart = self.output("restart", 1)
-        self.wire(self._restart, ~self._done & self._step)
+        self.wire(self._restart, self._step &  (~self._done))
 
     @always_comb
     # Find lowest ready

--- a/lake/modules/for_loop.py
+++ b/lake/modules/for_loop.py
@@ -79,7 +79,7 @@ class ForLoop(Generator):
         # GENERATION LOGIC: end
 
         self._restart = self.output("restart", 1)
-        self.wire(self._restart, self._step &  (~self._done))
+        self.wire(self._restart, self._step & (~self._done))
 
     @always_comb
     # Find lowest ready


### PR DESCRIPTION
@kuree - The previous code was dropping the  `& self._step` from the Verilog. My reordering fixes the codegen and needs to go in ASAP so we will not wait for a Kratos fix.