### PR TITLE
Add a separate accessors conv_3_3 test for CI

### DIFF
--- a/lake/utils/test_infra.py
+++ b/lake/utils/test_infra.py
@@ -80,16 +80,13 @@ def gen_test_lake(config_path,
             if i < len(out_data[j]):
                 if len(valids) != 0 and valids[i] == 1:
                     getattr(tester.circuit, f"data_out_{j}").expect(out_data[j][i])
-                elif len(valids) == 0:
-                    getattr(tester.circuit, f"data_out_{j}").expect(out_data[j][i])
 
         tester.step(2)
 
     with tempfile.TemporaryDirectory() as tempdir:
-        tempdir = "resnet5"
         tester.compile_and_run(target="verilator",
                                directory=tempdir,
-                               flags=["-Wno-fatal", "--trace"])
+                               flags=["-Wno-fatal"])
 
 
 def lake_test_app_args(app):
@@ -113,7 +110,7 @@ def conv_3_3_args():
 # This is a weird custom test path until we can get consistent paths
 def separate_args():
     clkwrk_dir = os.getenv("CLOCKWORK_DIR")
-    config_path = clkwrk_dir + "/aha_garnet_design_new/resnet/lake_collateral/ub_hw_input_global_wrapper_stencil_cyclic_0_0_0"
+    config_path = clkwrk_dir + "/aha_garnet_design_new/conv_3_3/lake_collateral/ub_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_2_to_hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_1_11"
     stream_path = clkwrk_dir + "/aha_garnet_design/conv_3_3/lake_stream/hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_2_to_hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_1_11_ubuf_0_top_SMT.csv"
     in_file_name = ""
     out_file_name = ""

--- a/lake/utils/test_infra.py
+++ b/lake/utils/test_infra.py
@@ -69,23 +69,19 @@ def gen_test_lake(config_path,
     for (f1, f2) in configs:
         setattr(tester.circuit, f1, f2)
 
-    # for i in range(len(out_data[0])):
-    for i in range(40000):
-        if i >= 10000:
-            tester.circuit.data_in_0 = i - 10000
-        # for j in range(len(in_data)):
-        #     if i < len(in_data[j]):
-        #         setattr(tester.circuit, f"data_in_{j}", in_data[j][i])
-        # tester.circuit.data_in_0 = i
+    for i in range(len(out_data[0])):
+        for j in range(len(in_data)):
+            if i < len(in_data[j]):
+                setattr(tester.circuit, f"data_in_{j}", in_data[j][i])
 
         tester.eval()
 
         for j in range(len(out_data)):
-            # if i < len(out_data[j]):
-            #     if len(valids) != 0 and valids[i] == 1:
-            #         getattr(tester.circuit, f"data_out_{j}").expect(out_data[j][i])
-            if len(valids) == 0:
-                getattr(tester.circuit, f"data_out_{j}").expect(out_data[j][i])
+            if i < len(out_data[j]):
+                if len(valids) != 0 and valids[i] == 1:
+                    getattr(tester.circuit, f"data_out_{j}").expect(out_data[j][i])
+                elif len(valids) == 0:
+                    getattr(tester.circuit, f"data_out_{j}").expect(out_data[j][i])
 
         tester.step(2)
 

--- a/tests/test_lake.py
+++ b/tests/test_lake.py
@@ -12,5 +12,6 @@ def test_lake(args):
 
 
 if __name__ == "__main__":
+    # separate accessors conv_3_3
     conv33args = lake_test_app_args("separate")
     test_lake(conv33args)


### PR DESCRIPTION
Lake CI does not currently have a test with Clockwork configs (got accidentally commented out during tapeout to test custom hard-coded resnet stuff)
PR adds separate accessors conv_3_3 as a test for CI.

garnet, aha branches: main_test
garnet uses functions from test_infra.py