### PR TITLE
enable full LakeTop annotation as well

### DIFF
--- a/lake/dsl/hw_top_lake.py
+++ b/lake/dsl/hw_top_lake.py
@@ -539,12 +539,6 @@ class TopLakeHW(Generator):
             ("tb12output_port1_read_sched_gen_enable", 1),
             ("tb12output_port1_forloop_dimensionality", tb2out1.dim),
 
-            # Control Signals...
-            ("flush_reg_sel", 0),  # 1
-            ("flush_reg_value", 0),  # 1
-
-            # Set the mode and activate the tile...
-            ("mode", 0),  # 2
             ("tile_en", 1),  # 1
         ]
 
@@ -562,15 +556,6 @@ class TopLakeHW(Generator):
             else:
                 print("No configuration file provided for stencil valid...are you expecting one to exist?")
                 print(f"Bogus stencil valid path: {cfg_path}")
-
-        # TODO: Maybe need to check if size 1?
-        for i in range(input_ports):
-            config.append((f"ren_in_{i}_reg_sel", 1))
-            config.append((f"ren_in_{i}_reg_value", 0))
-
-        for i in range(output_ports):
-            config.append((f"wen_in_{i}_reg_sel", 1))
-            config.append((f"wen_in_{i}_reg_value", 0))
 
         for i in range(in2agg.dim):
             config.append((f"input_port0_2agg0_forloop_ranges_{i}", in2agg.extent[i]))

--- a/lake/top/lake_top.py
+++ b/lake/top/lake_top.py
@@ -1082,21 +1082,21 @@ class LakeTop(Generator):
         config = []
 
         # control signals
-        config.append(("flush_reg_sel", 0))
-        config.append(("flush_reg_value", 0))
+        # config.append(("flush_reg_sel", 0))
+        # config.append(("flush_reg_value", 0))
 
         # set the mode and activate the tile
         config.append(("mode", 0))
         config.append(("tile_en", 1))
 
         # TODO: Maybe need to check if size 1?
-        for i in range(input_ports):
-            config.append((f"ren_in_{i}_reg_sel", 1))
-            config.append((f"ren_in_{i}_reg_value", 0))
+        # for i in range(input_ports):
+        #     config.append((f"ren_in_{i}_reg_sel", 1))
+        #     config.append((f"ren_in_{i}_reg_value", 0))
 
-        for i in range(output_ports):
-            config.append((f"wen_in_{i}_reg_sel", 1))
-            config.append((f"wen_in_{i}_reg_value", 0))
+        # for i in range(output_ports):
+        #     config.append((f"wen_in_{i}_reg_sel", 1))
+        #     config.append((f"wen_in_{i}_reg_value", 0))
 
         # Check the hardware if it supports stencil valid
         if self.stencil_valid:

--- a/lake/top/lake_top.py
+++ b/lake/top/lake_top.py
@@ -1280,6 +1280,7 @@ if __name__ == "__main__":
     if args.f is None:
         prefix = ""
         lake_dut, need_config_lift, use_sram_stub, tsmc_info = get_lake_dut()
+        extract_formal_annotation(lake_dut, f"lake_top_annotation.txt", "full")
     # optional: to add generator cuts for formal module verilog + annotations
     else:
         module = args.f

--- a/tests/test_agg_buffer.py
+++ b/tests/test_agg_buffer.py
@@ -6,6 +6,7 @@ import fault
 import tempfile
 import kratos as k
 import random as rand
+import pytest
 
 
 @pytest.mark.skip

--- a/tests/test_agg_buffer.py
+++ b/tests/test_agg_buffer.py
@@ -8,6 +8,7 @@ import kratos as k
 import random as rand
 
 
+@pytest.mark.skip
 def test_agg_buff_basic(agg_height=4,
                         data_width=16,
                         mem_width=64,

--- a/tests/test_app_ctrl.py
+++ b/tests/test_app_ctrl.py
@@ -11,6 +11,7 @@ import random as rand
 import pytest
 
 
+@pytest.mark.skip
 @pytest.mark.parametrize("sprt_stcl_valid", [True, False])
 def test_app_ctrl(sprt_stcl_valid,
                   int_in_ports=1,

--- a/tests/test_dsl_memtile.py
+++ b/tests/test_dsl_memtile.py
@@ -54,7 +54,7 @@ def gen_test_lake(config_path,
                          lt_dut)
 
     tester.circuit.clk_en = 1
-    tester.circuit.clk_mem = 0
+    tester.circuit.clk = 0
     tester.circuit.rst_n = 0
     tester.step(2)
     tester.circuit.rst_n = 1

--- a/tests/test_prefetcher.py
+++ b/tests/test_prefetcher.py
@@ -11,6 +11,7 @@ import random as rand
 import pytest
 
 
+@pytest.mark.skip
 def test_prefetcher_basic(input_latency=10,
                           max_prefetch=64,
                           fetch_width=32,

--- a/tests/test_reg_fifo.py
+++ b/tests/test_reg_fifo.py
@@ -62,7 +62,7 @@ def test_reg_fifo_basic(width_mult,
         tester.circuit.full.expect(full)
 
         mem_valid_data = rand.randint(0, 1)
-        tester.circuit.mem_valid_data = mem_valid_data
+        # tester.circuit.mem_valid_data = mem_valid_data
 
         (model_out, model_val, model_empty, model_full, model_mem_valid) = \
             model_rf.interact(push, pop, data_in, mem_valid_data)

--- a/tests/test_rw_arbiter.py
+++ b/tests/test_rw_arbiter.py
@@ -11,6 +11,7 @@ import random as rand
 import pytest
 
 
+@pytest.mark.skip
 @pytest.mark.parametrize("int_out_ports", [1, 2, 4])
 @pytest.mark.parametrize("fetch_width", [16, 32])
 @pytest.mark.parametrize("read_delay", [0, 1])

--- a/tests/test_sram.py
+++ b/tests/test_sram.py
@@ -39,13 +39,6 @@ def test_sram_basic(data_width,
     for key, value in new_config.items():
         setattr(tester.circuit, key, value)
 
-    # initial reset
-    tester.circuit.clk = 0
-    tester.circuit.rst_n = 0
-    tester.step(2)
-    tester.circuit.rst_n = 1
-    tester.step(2)
-
     rand.seed(0)
 
     data = [0 for i in range(width_mult)]

--- a/tests/test_sram_wrapper.py
+++ b/tests/test_sram_wrapper.py
@@ -63,13 +63,7 @@ def test_sram_wrapper(use_sram_stub=True,
     for key, value in new_config.items():
         setattr(tester.circuit, key, value)
 
-    tester.circuit.clk = 0
     tester.circuit.clk_en = 1
-    tester.circuit.rst_n = 1
-    tester.step(2)
-    tester.circuit.rst_n = 0
-    tester.step(2)
-    tester.circuit.rst_n = 1
 
     rand.seed(0)
 

--- a/tests/test_sync_groups.py
+++ b/tests/test_sync_groups.py
@@ -11,6 +11,7 @@ import random as rand
 import pytest
 
 
+@pytest.mark.skip
 @pytest.mark.parametrize("int_out_ports", [1, 2, 3])
 def test_sync_groups(int_out_ports,
                      fetch_width=32,

--- a/tests/test_tb_formal.py
+++ b/tests/test_tb_formal.py
@@ -11,6 +11,7 @@ import random as rand
 import pytest
 
 
+@pytest.mark.skip
 def test_tb_formal():
 
     tb_dut = TBFormal(data_width=16,  # CGRA Params


### PR DESCRIPTION
Small updates to extract formal annotation for full LakeTop like before (instead of just the module annotation files).

Fault was also updated to throw an error if a port that doesn't exist is used in the testbench so our tests had some lingering errors from there. This PR fixes those errors or skips deprecated tests.