### PR TITLE
Gets rid of tester compile and run in wrapper and uses kratos flatten method instead for verilog generation

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,6 +1,6 @@
 import pytest
 from magma import clear_cachedFunctions
-import magma.backend.coreir_ as coreir_
+# import magma.backend.coreir_ as coreir_
 from kratos import clear_context
 
 collect_ignore = [
@@ -10,7 +10,7 @@ collect_ignore = [
 @pytest.fixture(autouse=True)
 def kratos_test():
     clear_cachedFunctions()
-    coreir_.CoreIRContextSingleton().reset_instance()
+    # coreir_.CoreIRContextSingleton().reset_instance()
     clear_context()
 
 def pytest_addoption(parser):

--- a/tests/wrapper_lake.py
+++ b/tests/wrapper_lake.py
@@ -25,11 +25,20 @@ def get_lake_wrapper(config_path,
     # prints out list of configs for compiler team
     configs_list = set_configs_sv(lt_dut, "configs.sv", get_configs_dict(configs))
 
+    # get flattened module
     flattened = create_wrapper_flatten(lt_dut.internal_generator.clone(),
                                        "LakeTop_W")
     inst = Generator("LakeTop_W",
                      internal_generator=flattened)
     verilog(inst, filename="LakeTop_W.v")
+
+    # get original verilog
+    verilog(lt_dut, filename="lt_dut.v")
+    # prepend wrapper module to original verilog file
+    with open("LakeTop_W.v", "a") as with_flatten:
+        with open("lt_dut.v", "r") as lt_dut_file:
+            for line in lt_dut_file:
+                with_flatten.write(line)
     
     generate_lake_config_wrapper(configs_list, "configs.sv", "LakeTop_W.v", name)
 

--- a/tests/wrapper_lake.py
+++ b/tests/wrapper_lake.py
@@ -9,6 +9,7 @@ from lake.top.lake_top import get_lake_dut
 
 from _kratos import create_wrapper_flatten
 
+
 def get_lake_wrapper(config_path,
                      stencil_valid,
                      name,
@@ -39,7 +40,7 @@ def get_lake_wrapper(config_path,
         with open("lt_dut.v", "r") as lt_dut_file:
             for line in lt_dut_file:
                 with_flatten.write(line)
-    
+
     generate_lake_config_wrapper(configs_list, "configs.sv", "LakeTop_W.v", name)
 
 


### PR DESCRIPTION
Gets rid of tester compile and run in wrapper and uses kratos flatten method instead for verilog generation