### PR TITLE
Add an interface for deciding to use sram stub

### DIFF
--- a/lake/top/lake_top.py
+++ b/lake/top/lake_top.py
@@ -31,7 +31,7 @@ class LakeTop(Generator):
                  interconnect_output_ports=2,
                  mem_input_ports=1,
                  mem_output_ports=1,
-                 use_sram_stub=True,
+                 use_sram_stub=False,
                  sram_macro_info=SRAMMacroInfo("tsmc_name"),
                  read_delay=1,  # Cycle delay in read (SRAM vs Register File)
                  rw_same_cycle=False,  # Does the memory allow r+w in same cycle?
@@ -113,7 +113,7 @@ class LakeTop(Generator):
         MTB.set_memory_interface(name_prefix=name_prefix,
                                  mem_params=memory_params,
                                  ports=tsmc_mem,
-                                 sim_macro_n=not self.use_sram_stub,
+                                 sim_macro_n=self.use_sram_stub,
                                  tech_map=tech_map)
 
         # Now add the controllers in...

--- a/lake/utils/wrapper.py
+++ b/lake/utils/wrapper.py
@@ -105,6 +105,11 @@ if __name__ == "__main__":
                         help="use dual port sram",
                         default=False)
 
+    parser.add_argument("-stub",
+                        action='store_true',
+                        help="use sram stub for clockwork verilator simulation",
+                        default=True)
+
     parser.add_argument("-v",
                         action='store_true',
                         help='Generate main verilog')
@@ -156,6 +161,7 @@ if __name__ == "__main__":
         lake_kwargs['mem_depth'] = args.d
         lake_kwargs['rw_same_cycle'] = args.dp
         lake_kwargs['input_iterator_support'] = args.ii
+        lake_kwargs['use_sram_stub'] = args.stub
         lake_kwargs['output_iterator_support'] = args.oi
         lake_kwargs['read_delay'] = args.rd
         lake_kwargs['name'] = args.vmn


### PR DESCRIPTION
I noticed a recent change in this branch that break clockwork verilator simulation. 
The clockwork simulation do require to use sram stub. So I add an interface to the wrapper. 