### PR TITLE
Parameterize 17bit data width

### DIFF
--- a/lake/top/lake_top.py
+++ b/lake/top/lake_top.py
@@ -141,6 +141,7 @@ class LakeTop(Generator):
                                          interconnect_output_ports=self.interconnect_output_ports,
                                          read_delay=self.read_delay,
                                          rw_same_cycle=self.rw_same_cycle,
+                                         comply_with_17=self.comply_with_17,
                                          agg_height=self.agg_height,
                                          config_width=self.config_width,
                                          area_opt=self.area_opt,


### PR DESCRIPTION
Instead of hard-coding bitwidth to 17bit, I added a parameter `comply_with_17` to `strg_ub_vec` module.