### PR TITLE
Sparse metamapper

### DIFF
--- a/lake/modules/onyx_dense_pe.py
+++ b/lake/modules/onyx_dense_pe.py
@@ -144,10 +144,7 @@ class OnyxDensePE(MemoryController):
         config = [("tile_en", 1)]
 
         op = config_kwargs['op']
-        override_dense = False
-
-        only_dense_hw = True
-        sub_config = self.my_alu.get_bitstream(op=op, override_dense=override_dense, config_kwargs=config_kwargs, only_dense_hw=only_dense_hw)
+        sub_config = self.my_alu.get_bitstream(op=op)
         for config_tuple in sub_config:
             config_name, config_value = config_tuple
             config += [(f"{self.my_alu.instance_name}_{config_name}", config_value)]

--- a/lake/modules/onyx_pe.py
+++ b/lake/modules/onyx_pe.py
@@ -75,65 +75,24 @@ class OnyxPE(MemoryController):
             tmp_data_in.add_attribute(ControlSignalAttr(is_control=False, full_bus=True))
             # Mark as hybrid port to allow bypassing at the core combiner level
             tmp_data_in.add_attribute(HybridPortAddr())
-            # self._data_in = self.input("data_in", self.data_width, size=2, explicit_array=True, packed=True)
 
             tmp_data_in_valid_in = self.input(f"data{i}_valid", 1)
             tmp_data_in_valid_in.add_attribute(ControlSignalAttr(is_control=True))
-            # self._valid_in = self.input("valid_in", 2)
 
             tmp_data_in_ready_out = self.output(f"data{i}_ready", 1)
             tmp_data_in_ready_out.add_attribute(ControlSignalAttr(is_control=False))
-            # self._ready_out = self.output("ready_out", 2)
-
-            # tmp_data_in_eos_in = self.var(f"data{i}_eos", 1)
-            # tmp_data_in_eos_in.add_attribute(ControlSignalAttr(is_control=True))
-            # self.wire(tmp_data_in_eos_in, tmp_data_in[self.data_width])
-            # self._eos_in = self.input("eos_in", 2)
 
             self._data_in.append(tmp_data_in)
             self._data_in_valid_in.append(tmp_data_in_valid_in)
             self._data_in_ready_out.append(tmp_data_in_ready_out)
-            # self._data_in_eos_in.append(tmp_data_in_eos_in)
-
-        # for i in range(3):
-
-        # tmp_data_in = self.input(f"data2", self.data_width + 1, packed=True)
-        # tmp_data_in.add_attribute(ControlSignalAttr(is_control=False, full_bus=True))
-        # self._data_in = self.input("data_in", self.data_width, size=2, explicit_array=True, packed=True)
-
-        # tmp_data_in_valid_in = self.input(f"data2_valid", 1)
-        # tmp_data_in_valid_in.add_attribute(ControlSignalAttr(is_control=True))
-        # self._valid_in = self.input("valid_in", 2)
-
-        # tmp_data_in_ready_out = self.output(f"data2_ready", 1)
-        # tmp_data_in_ready_out.add_attribute(ControlSignalAttr(is_control=False))
-        # self._ready_out = self.output("ready_out", 2)
-
-        # tmp_data_in_eos_in = self.var(f"data2_eos", 1)
-        # tmp_data_in_eos_in.add_attribute(ControlSignalAttr(is_control=True))
-        # self.wire(tmp_data_in_eos_in, tmp_data_in[self.data_width])
-        # self._eos_in = self.input("eos_in", 2)
 
         self._data_in.append(tmp_data_in)
-        # self._data_in_eos_in.append(tmp_data_in_eos_in)
 
         self._bit_in = []
-        # self._data_in_valid_in = []
-        # self._data_in_ready_out = []
-        # self._data_in_eos_in = []
-
         for i in range(3):
 
             tmp_data_in = self.input(f"bit{i}", 1)
             tmp_data_in.add_attribute(ControlSignalAttr(is_control=True, full_bus=False))
-            # self._data_in = self.input("data_in", self.data_width, size=2, explicit_array=True, packed=True)
-
-            # tmp_data_in_valid_in = self.input(f"bit{i}_valid", 1)
-            # tmp_data_in_valid_in.add_attribute(ControlSignalAttr(is_control=True))
-
-            # tmp_data_in_ready_out = self.output(f"bit{i}_ready", 1)
-            # tmp_data_in_ready_out.add_attribute(ControlSignalAttr(is_control=False))
-
             self._bit_in.append(tmp_data_in)
 
         self._data_out = self.output("res", self.data_width + 1, packed=True)
@@ -247,7 +206,6 @@ class OnyxPE(MemoryController):
         self.wire(self._outfifo_in_packed[self.data_width], self._outfifo_in_eos)
         self.wire(self._outfifo_in_packed[self.data_width - 1, 0], self._data_to_fifo)
 
-        # self.wire(self._eos_out, self._outfifo_out_packed[self.data_width])
         self.wire(self._data_out, kts.ternary(self._dense_mode, self._pe_output, self._outfifo_out_packed))
 
         # Push when there's incoming transaction and room to accept it
@@ -256,7 +214,6 @@ class OnyxPE(MemoryController):
         # Pop when ready to accum more streams
         self._outfifo_pop = self.var("outfifo_pop", 1)
         self._outfifo_full = self.var("outfifo_full", 1)
-        # self._outfifo_empty = self.var("outfifo_empty", 1)
 
         self.add_child(f"output_fifo",
                        self._outfifo,
@@ -272,17 +229,10 @@ class OnyxPE(MemoryController):
 
         self.wire(self._outfifo_pop, self._ready_in)
         self.wire(self._outfifo_full, self._outfifo.ports.full)
-        # self.wire(self._outfifo_empty, self._outfifo.ports.empty)
 
 # =============================
 # Instantiate actual PE
 # =============================
-
-        # self._execute_op = self.var("execute_op", 1)
-        # self.wire(self._execute_op, (self._infifo_out_valid.r_and() & ~self._infifo_out_eos.r_or() & ~self._outfifo_full))
-
-        # self._op = self.input("op", 1)
-        # self._op.add_attribute(ConfigRegAttr("Operation"))
 
         self.my_alu = OnyxPEInterface(data_width=self.data_width,
                                       name_prefix=self.ext_pe_prefix,
@@ -395,7 +345,7 @@ class OnyxPE(MemoryController):
         else:
             config += [("dense_mode", 0)]
 
-        sub_config = self.my_alu.get_bitstream(op=op, config_kwargs=config_kwargs)
+        sub_config = self.my_alu.get_bitstream(op=op)
         for config_tuple in sub_config:
             config_name, config_value = config_tuple
             config += [(f"{self.my_alu.instance_name}_{config_name}", config_value)]

--- a/lake/modules/onyx_pe.py
+++ b/lake/modules/onyx_pe.py
@@ -393,13 +393,7 @@ class OnyxPE(MemoryController):
             # We want to bypass the fifos
             config += [("dense_mode", 1)]
         else:
-            # we are deploying the pe in sparse mode
-            if config_kwargs["rb_const"] is not None:
-                # the b operand is a constant
-                # support constant operand for and and fp_mul for now
-                assert op == 5 or op == 6
-                # only accepting one input from port a
-                sparse_num_inputs = 0b001
+            config += [("dense_mode", 0)]
 
         sub_config = self.my_alu.get_bitstream(op=op, config_kwargs=config_kwargs)
         for config_tuple in sub_config:

--- a/lake/modules/onyx_pe_intf.py
+++ b/lake/modules/onyx_pe_intf.py
@@ -75,7 +75,7 @@ class OnyxPEInterface(MemoryController):
     def get_config_mode_str(self):
         return "alu_ext"
 
-    def get_bitstream(self, op, config_kwargs, override_dense=False):
+    def get_bitstream(self, op, config_kwargs):
 
         instr_type = strip_modifiers(lassen_fc.Py.input_t.field_dict['inst'])
         asm_ = Assembler(instr_type)
@@ -90,31 +90,7 @@ class OnyxPEInterface(MemoryController):
             # config the value of b port constant
             kwargs["rb_const"] = config_kwargs["rb_const"]
 
-        opcode_mapping = {
-            0: asm.add(**kwargs),  # ADD
-            1: asm.smult0(**kwargs),  # MUL
-            2: asm.sub(**kwargs),   # SUB
-            3: asm.abs(**kwargs),   # abs
-            4: asm.smax(**kwargs),   # smax
-            5: asm.and_(**kwargs),
-            6: asm.fp_mul(**kwargs),
-            7: asm.fgetfint(**kwargs),
-            8: asm.fgetffrac(**kwargs),
-            9: asm.faddiexp(**kwargs),
-            10: asm.fp_max(**kwargs),
-            11: asm.fp_add(**kwargs),
-        }
-
-        if override_dense:
-            print(f"OVERRIDE DENSE CONFIG: {op}")
-            op_config = op
-        else:
-            if op not in opcode_mapping:
-                raise NotImplementedError
-            pe_bs = asm_.assemble(opcode_mapping[op])
-            op_config = int(pe_bs)
-
-        config_base = [("inst", op_config)]
+        config_base = [("inst", op)]
         config = self.chop_config(config_base=config_base)
 
         return config

--- a/lake/modules/onyx_pe_intf.py
+++ b/lake/modules/onyx_pe_intf.py
@@ -76,23 +76,8 @@ class OnyxPEInterface(MemoryController):
         return "alu_ext"
 
     def get_bitstream(self, op, config_kwargs):
-
-        instr_type = strip_modifiers(lassen_fc.Py.input_t.field_dict['inst'])
-        asm_ = Assembler(instr_type)
-
-        kwargs = {}
-        if "rb_const" in config_kwargs and config_kwargs["rb_const"] is not None:
-            # the b operand is a constant
-            # support constant operand for and and fp_mul for now
-            assert op == 5 or op == 6
-            # config the b port of pe to constant mode
-            kwargs["rb_mode"] = Mode_t.CONST
-            # config the value of b port constant
-            kwargs["rb_const"] = config_kwargs["rb_const"]
-
         config_base = [("inst", op)]
         config = self.chop_config(config_base=config_base)
-
         return config
 
 

--- a/lake/modules/onyx_pe_intf.py
+++ b/lake/modules/onyx_pe_intf.py
@@ -56,13 +56,8 @@ class OnyxPEInterface(MemoryController):
             self._O4 = self.output("O4", self.data_width)
             self._O4.add_attribute(ConfigRegAttr("PIPE REG 2", read_only=True))
 
-        # self._config_addr = self.input("config_addr", 8)
-        # self._config_data = self.input("config_data", 32)
-        # self._config_en = self.input("config_en", 1)
-
         self._O0 = self.output("O0", self.data_width)
         self._O1 = self.output("O1", 1)
-        # self._O2 = self.output("O2", 2 * self.data_width)
 
         self.external = True
 
@@ -75,7 +70,7 @@ class OnyxPEInterface(MemoryController):
     def get_config_mode_str(self):
         return "alu_ext"
 
-    def get_bitstream(self, op, config_kwargs):
+    def get_bitstream(self, op):
         config_base = [("inst", op)]
         config = self.chop_config(config_base=config_base)
         return config


### PR DESCRIPTION
1. Remove all the hard coded opcode generation for the PE (now using metamapper)
2. Remove all the hard coded sparse_num_input for the PE (now using metamapper)
3. Remove commented codes that are not used