### PR TITLE
Fix broken CI

### DIFF
--- a/.github/scripts/run.sh
+++ b/.github/scripts/run.sh
@@ -6,19 +6,14 @@ cd /lake
 
 source scripts/setenv.sh
 
-
-
-
-
-
 # force color
 export PYTEST_ADDOPTS="--color=yes"
 
-# Do we really need these?
-# echo pip install py, apt-get install verilator
-# pip install py
-# apt-get update
-# apt-get install verilator
+echo pip install py, apt-get install verilator
+set -x
+pip install py | yes
+apt-get update
+apt-get install verilator
 
 echo python3 -m pycodestyle lake/
 python3 -m pycodestyle lake/

--- a/.github/scripts/run.sh
+++ b/.github/scripts/run.sh
@@ -6,6 +6,11 @@ cd /lake
 
 source scripts/setenv.sh
 
+
+
+
+
+
 # force color
 export PYTEST_ADDOPTS="--color=yes"
 

--- a/.github/scripts/run.sh
+++ b/.github/scripts/run.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-# This script is completely unused now, I think, but I'm too chicken to delete it.
-
+# As of April 2024: This script is completely unused now,
+# I think, but I'm too chicken to delete it :)
 
 set +x
 set -e
@@ -14,10 +14,9 @@ source scripts/setenv.sh
 export PYTEST_ADDOPTS="--color=yes"
 
 echo pip install py, apt-get install verilator
-set -x
-yes | pip install py | head -100
+pip install py
 apt-get update
-# apt-get install verilator
+apt-get install verilator
 
 echo python3 -m pycodestyle lake/
 python3 -m pycodestyle lake/

--- a/.github/scripts/run.sh
+++ b/.github/scripts/run.sh
@@ -9,10 +9,11 @@ source scripts/setenv.sh
 # force color
 export PYTEST_ADDOPTS="--color=yes"
 
-echo pip install py, apt-get install verilator
-pip install py
-apt-get update
-apt-get install verilator
+# Do we really need these?
+# echo pip install py, apt-get install verilator
+# pip install py
+# apt-get update
+# apt-get install verilator
 
 echo python3 -m pycodestyle lake/
 python3 -m pycodestyle lake/

--- a/.github/scripts/run.sh
+++ b/.github/scripts/run.sh
@@ -13,7 +13,7 @@ echo pip install py, apt-get install verilator
 set -x
 yes | pip install py | head -100
 apt-get update
-apt-get install verilator
+# apt-get install verilator
 
 echo python3 -m pycodestyle lake/
 python3 -m pycodestyle lake/

--- a/.github/scripts/run.sh
+++ b/.github/scripts/run.sh
@@ -11,7 +11,7 @@ export PYTEST_ADDOPTS="--color=yes"
 
 echo pip install py, apt-get install verilator
 set -x
-pip install py | yes
+yes | pip install py | head -100
 apt-get update
 apt-get install verilator
 

--- a/.github/scripts/run.sh
+++ b/.github/scripts/run.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+
+# This script is completely unused now, I think, but I'm too chicken to delete it.
+
+
 set +x
 set -e
 

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -10,54 +10,23 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-
     - name: Checkout submodules
       shell: bash
       run: |
         auth_header="$(git config --local --get http.https://github.com/.extraheader)"
         git submodule sync --recursive
         git -c "http.extraheader=$auth_header" -c protocol.version=2 submodule update --init --force --recursive --depth=1
-
     - name: Pull and run docker 🐋 
       shell: bash
       run: |
         docker run -it -d --name lakebox --mount type=bind,source="$(pwd)"/../lake,target=/lake stanfordaha/garnet:latest bash
-
     - name: Run tests ⚙️
       shell: bash
       run: |
-        # docker exec -i lakebox bash -c 'lake/.github/scripts/run.sh'
-        # Replace docker lake with target lake
+        # Remove docker lake and insert our version that we want to test
         docker exec -i lakebox /bin/bash -c "rm -rf /aha/lake"
         docker cp ../lake lakebox:/aha/lake
-        # Install venv and verilator
+        # Tests require installation of verilator
         docker exec -i lakebox bash -c 'yes | apt-get install verilator'
-        # Run the tests already omg
+        # Run the tests
         docker exec -i lakebox bash -c 'source /aha/bin/activate; cd lake; pytest -v tests/'
-
-
-#     - name: Install deps 🛠️
-#       shell: bash
-#       run: |
-#         docker exec -i lakebox bash -c 'apt update && apt install -y libgmp-dev libmpfr-dev libmpc-dev python3-dev'
-#         docker exec -i lakebox bash -c 'python3 -m pip install --upgrade pip'
-#         docker exec -i lakebox bash -c 'python3 -m pip install setuptools wheel'
-#         #
-#         # Fault be muckin' us up maybe
-#         # docker exec -i lakebox bash -c 'python3 -m pip install pytest fault pytest-codestyle pycodestyle'
-#         docker exec -i lakebox bash -c 'python3 -m pip install pytest pytest-codestyle pycodestyle'
-#         #
-#         docker exec -i lakebox bash -c 'python3 -m pip install importlib_resources'
-#         #
-#         # Already have sam I think, complains when try to reinstall anyway
-#         # docker exec -i lakebox bash -c 'git clone https://github.com/weiya711/sam.git && cd sam && python3 -m pip install -e .'
-#         #
-#         docker exec -i lakebox /bin/bash -c "rm -rf /aha/lake"
-#         docker cp ../lake lakebox:/aha/lake
-#         #
-#         # May not actually need/want this???
-#         # docker exec -i lakebox bash -c 'cd lake && python3 -m pip install -e .'
-#     - name: Run tests ⚙️
-#       shell: bash
-#       run: |
-#         docker exec -i lakebox bash -c 'lake/.github/scripts/run.sh'

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Pull and run docker 🐋 
       shell: bash
       run: |
-        docker run -it -d --name lake --mount type=bind,source="$(pwd)"/../lake,target=/lake keyiz/kratos-full bash
+        docker run -it -d --name lake --mount type=bind,source="$(pwd)"/../lake,target=/lake stanfordaha/garnet:latest bash
     - name: Install deps 🛠️
       shell: bash
       run: |

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -19,18 +19,22 @@ jobs:
     - name: Pull and run docker 🐋 
       shell: bash
       run: |
-        docker run -it -d --name lake --mount type=bind,source="$(pwd)"/../lake,target=/lake stanfordaha/garnet:latest bash
+        docker run -it -d --name lakebox --mount type=bind,source="$(pwd)"/../lake,target=/lake stanfordaha/garnet:latest bash
     - name: Install deps 🛠️
       shell: bash
       run: |
-        docker exec -i lake bash -c 'apt update && apt install -y libgmp-dev libmpfr-dev libmpc-dev python3-dev'
-        docker exec -i lake bash -c 'python3 -m pip install --upgrade pip'
-        docker exec -i lake bash -c 'python3 -m pip install setuptools wheel'
-        docker exec -i lake bash -c 'python3 -m pip install pytest fault pytest-codestyle pycodestyle'
-        docker exec -i lake bash -c 'python3 -m pip install importlib_resources'
-        # docker exec -i lake bash -c 'git clone https://github.com/weiya711/sam.git && cd sam && python3 -m pip install -e .'
-        docker exec -i lake bash -c 'cd lake && python3 -m pip install -e .'
+        docker exec -i lakebox bash -c 'apt update && apt install -y libgmp-dev libmpfr-dev libmpc-dev python3-dev'
+        docker exec -i lakebox bash -c 'python3 -m pip install --upgrade pip'
+        docker exec -i lakebox bash -c 'python3 -m pip install setuptools wheel'
+        docker exec -i lakebox bash -c 'python3 -m pip install pytest fault pytest-codestyle pycodestyle'
+        docker exec -i lakebox bash -c 'python3 -m pip install importlib_resources'
+        # docker exec -i lakebox bash -c 'git clone https://github.com/weiya711/sam.git && cd sam && python3 -m pip install -e .'
+        #
+        docker exec -i lakebox /bin/bash -c "rm -rf /aha/lake"
+        docker cp ../lake lakebox:/aha/lake
+        #
+        docker exec -i lakebox bash -c 'cd lake && python3 -m pip install -e .'
     - name: Run tests ⚙️
       shell: bash
       run: |
-        docker exec -i lake bash -c 'lake/.github/scripts/run.sh'
+        docker exec -i lakebox bash -c 'lake/.github/scripts/run.sh'

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -26,8 +26,14 @@ jobs:
         docker exec -i lakebox bash -c 'apt update && apt install -y libgmp-dev libmpfr-dev libmpc-dev python3-dev'
         docker exec -i lakebox bash -c 'python3 -m pip install --upgrade pip'
         docker exec -i lakebox bash -c 'python3 -m pip install setuptools wheel'
-        docker exec -i lakebox bash -c 'python3 -m pip install pytest fault pytest-codestyle pycodestyle'
+        #
+        # Fault be muckin' us up maybe
+        # docker exec -i lakebox bash -c 'python3 -m pip install pytest fault pytest-codestyle pycodestyle'
+        docker exec -i lakebox bash -c 'python3 -m pip install pytest pytest-codestyle pycodestyle'
+        #
         docker exec -i lakebox bash -c 'python3 -m pip install importlib_resources'
+        #
+        # Already have sam I think, complains when try to reinstall anyway
         # docker exec -i lakebox bash -c 'git clone https://github.com/weiya711/sam.git && cd sam && python3 -m pip install -e .'
         #
         docker exec -i lakebox /bin/bash -c "rm -rf /aha/lake"

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -28,7 +28,7 @@ jobs:
         docker exec -i lake bash -c 'python3 -m pip install setuptools wheel'
         docker exec -i lake bash -c 'python3 -m pip install pytest fault pytest-codestyle pycodestyle'
         docker exec -i lake bash -c 'python3 -m pip install importlib_resources'
-        docker exec -i lake bash -c 'git clone https://github.com/weiya711/sam.git && cd sam && python3 -m pip install -e .'
+        # docker exec -i lake bash -c 'git clone https://github.com/weiya711/sam.git && cd sam && python3 -m pip install -e .'
         docker exec -i lake bash -c 'cd lake && python3 -m pip install -e .'
     - name: Run tests ⚙️
       shell: bash

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -39,7 +39,8 @@ jobs:
         docker exec -i lakebox /bin/bash -c "rm -rf /aha/lake"
         docker cp ../lake lakebox:/aha/lake
         #
-        docker exec -i lakebox bash -c 'cd lake && python3 -m pip install -e .'
+        # May not actually need/want this???
+        # docker exec -i lakebox bash -c 'cd lake && python3 -m pip install -e .'
     - name: Run tests ⚙️
       shell: bash
       run: |

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -31,10 +31,9 @@ jobs:
         docker exec -i lakebox /bin/bash -c "rm -rf /aha/lake"
         docker cp ../lake lakebox:/aha/lake
         # Install venv and verilator
-        docker exec -i lakebox bash -c 'source /aha/bin/activate'
         docker exec -i lakebox bash -c 'yes | apt-get install verilator'
         # Run the tests already omg
-        docker exec -i lakebox bash -c 'cd lake; pytest -v tests/'
+        docker exec -i lakebox bash -c 'source /aha/bin/activate; cd lake; pytest -v tests/'
 
 
 #     - name: Install deps 🛠️

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -10,38 +10,55 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+
     - name: Checkout submodules
       shell: bash
       run: |
         auth_header="$(git config --local --get http.https://github.com/.extraheader)"
         git submodule sync --recursive
         git -c "http.extraheader=$auth_header" -c protocol.version=2 submodule update --init --force --recursive --depth=1
+
     - name: Pull and run docker 🐋 
       shell: bash
       run: |
         docker run -it -d --name lakebox --mount type=bind,source="$(pwd)"/../lake,target=/lake stanfordaha/garnet:latest bash
-    - name: Install deps 🛠️
-      shell: bash
-      run: |
-        docker exec -i lakebox bash -c 'apt update && apt install -y libgmp-dev libmpfr-dev libmpc-dev python3-dev'
-        docker exec -i lakebox bash -c 'python3 -m pip install --upgrade pip'
-        docker exec -i lakebox bash -c 'python3 -m pip install setuptools wheel'
-        #
-        # Fault be muckin' us up maybe
-        # docker exec -i lakebox bash -c 'python3 -m pip install pytest fault pytest-codestyle pycodestyle'
-        docker exec -i lakebox bash -c 'python3 -m pip install pytest pytest-codestyle pycodestyle'
-        #
-        docker exec -i lakebox bash -c 'python3 -m pip install importlib_resources'
-        #
-        # Already have sam I think, complains when try to reinstall anyway
-        # docker exec -i lakebox bash -c 'git clone https://github.com/weiya711/sam.git && cd sam && python3 -m pip install -e .'
-        #
-        docker exec -i lakebox /bin/bash -c "rm -rf /aha/lake"
-        docker cp ../lake lakebox:/aha/lake
-        #
-        # May not actually need/want this???
-        # docker exec -i lakebox bash -c 'cd lake && python3 -m pip install -e .'
+
     - name: Run tests ⚙️
       shell: bash
       run: |
-        docker exec -i lakebox bash -c 'lake/.github/scripts/run.sh'
+        # docker exec -i lakebox bash -c 'lake/.github/scripts/run.sh'
+        # Replace docker lake with target lake
+        docker exec -i lakebox /bin/bash -c "rm -rf /aha/lake"
+        docker cp ../lake lakebox:/aha/lake
+        # Install venv and verilator
+        docker exec -i lakebox bash -c 'source /aha/bin/activate'
+        docker exec -i lakebox bash -c 'yes | apt-get install verilator'
+        # Run the tests already omg
+        docker exec -i lakebox bash -c 'cd lake; pytest -v tests/'
+
+
+#     - name: Install deps 🛠️
+#       shell: bash
+#       run: |
+#         docker exec -i lakebox bash -c 'apt update && apt install -y libgmp-dev libmpfr-dev libmpc-dev python3-dev'
+#         docker exec -i lakebox bash -c 'python3 -m pip install --upgrade pip'
+#         docker exec -i lakebox bash -c 'python3 -m pip install setuptools wheel'
+#         #
+#         # Fault be muckin' us up maybe
+#         # docker exec -i lakebox bash -c 'python3 -m pip install pytest fault pytest-codestyle pycodestyle'
+#         docker exec -i lakebox bash -c 'python3 -m pip install pytest pytest-codestyle pycodestyle'
+#         #
+#         docker exec -i lakebox bash -c 'python3 -m pip install importlib_resources'
+#         #
+#         # Already have sam I think, complains when try to reinstall anyway
+#         # docker exec -i lakebox bash -c 'git clone https://github.com/weiya711/sam.git && cd sam && python3 -m pip install -e .'
+#         #
+#         docker exec -i lakebox /bin/bash -c "rm -rf /aha/lake"
+#         docker cp ../lake lakebox:/aha/lake
+#         #
+#         # May not actually need/want this???
+#         # docker exec -i lakebox bash -c 'cd lake && python3 -m pip install -e .'
+#     - name: Run tests ⚙️
+#       shell: bash
+#       run: |
+#         docker exec -i lakebox bash -c 'lake/.github/scripts/run.sh'


### PR DESCRIPTION
Previously, lake CI was running pytests in a docker container "keyiz/kratos-full," of unknown provenance for unknown reasons. In addition, it did this weird thing where it creates a mount point "/lake" and connects it to the github lake version under test, then later calls "run.sh", which does a cd to /lake and runs the pytests there. Also, rather than using the docker environment, the previous test installed its own versions of certain requirements e.g. "sam," "fault," etc.

The old tests failed because a newer version of magma has arrived, which is now incompatible with lake :(
So when the old test installed anything with a magma dependence (e.g. "pip install fault"), it installed the newer magma as a secondary dependence, and the tests failed.

The changes in this pull request are designed to simplify the whole process. Now, we run the lake pytests in the same context that lake is generally used, i.e. in the "garnet:latest" docker container using that docker image's environment. (I mean, that's what the docker is for, right?)

"garnet:latest" uses the older version of magma/fault/etc., so the tests now pass again, see e.g.
https://github.com/StanfordAHA/lake/actions/runs/8675301132/job/23788593579

The bad news is that someday we will have to update the code when/if we ever want to use the latest magma. But that's a job for another day.
