### PR TITLE
Dense scanner fix

### DIFF
--- a/SPARSE_UNIT_TEST/Makefile
+++ b/SPARSE_UNIT_TEST/Makefile
@@ -18,6 +18,7 @@ TOP ?= 0
 TEST_UNIT ?= 0
 INST ?= 0
 NUM_INPUTS ?= 0
+FIBER_ACCESS_ROOT ?= 0
 
 export WAVEFORM ?= 0
 # export WAVEFORM_GLB_ONLY ?= 0
@@ -115,7 +116,8 @@ XRUN = xrun \
 # Compile & Run
 # -------------------------------------------------------------------
 COMPILE_RTL_ARGS += +define+CLK_PERIOD=$(CLK_PERIOD) \
-					+define+TX_NUM_GLB=$(TX_NUM_GLB)
+					+define+TX_NUM_GLB=$(TX_NUM_GLB) \
+					+define+FIBER_ACCESS_ROOT=$(FIBER_ACCESS_ROOT)
 
 COMPILE_GLS_ARGS += +define+CLK_PERIOD=$(CLK_PERIOD) \
 					+define+TX_NUM_GLB=$(TX_NUM_GLB)

--- a/SPARSE_UNIT_TEST/fiber_access_dense_tb.sv
+++ b/SPARSE_UNIT_TEST/fiber_access_dense_tb.sv
@@ -2,6 +2,9 @@
 `ifndef TX_NUM_GLB
 `define TX_NUM_GLB 1
 `endif
+`ifndef FIBER_ACCESS_ROOT
+`define FIBER_ACCESS_ROOT 0
+`endif
 
 module fiber_access_dense_tb;
 
@@ -84,7 +87,7 @@ fiber_access_16 dut
     .read_scanner_pos_out_ready(pos_out_0_ready),
     .read_scanner_repeat_factor(16'b0),
     .read_scanner_repeat_outer_inner_n(1'b0),
-    .read_scanner_root(1'b0),
+    .read_scanner_root(`FIBER_ACCESS_ROOT),
     // .read_scanner_spacc_mode(1'b0),
     // .read_scanner_stop_lvl(16'b0),
     .read_scanner_tile_en(tile_en),

--- a/SPARSE_UNIT_TEST/fiber_access_dense_tb.sv
+++ b/SPARSE_UNIT_TEST/fiber_access_dense_tb.sv
@@ -48,7 +48,7 @@ module fiber_access_dense_tb;
     wire rs_blk_valid;
     wire rs_blk_ready;
 
-    assign {ws_addr, ws_addr_valid, ws_blk, ws_blk_valid} = 35'b0;
+    assign {ws_addr, ws_addr_valid, coord_in_0, coord_in_0_valid} = 0;
     assign {rs_blk, rs_blk_valid} = 17'b0;
 
     logic [1:0] [31:0] config_out;
@@ -66,7 +66,7 @@ module fiber_access_dense_tb;
     integer wait_gap = 0; // should pass with arb gap
     integer DONE_TOKEN = 17'h10100;
 
-    fiber_access_16 dut 
+fiber_access_16 dut 
     (
     .buffet_buffet_capacity_log({4'b1000, 4'b1000}),
     .data_from_mem(memory_0_data_out_p0),
@@ -78,7 +78,6 @@ module fiber_access_dense_tb;
     .read_scanner_block_rd_out_ready(rs_blk_ready),
     .read_scanner_coord_out_ready(coord_out_ready),
     .read_scanner_dense(1'b1),
-    // .read_scanner_dim_size(16'b0),
     .read_scanner_do_repeat(1'b0),
     .read_scanner_inner_dim_offset(16'b0),
     .read_scanner_lookup(1'b0),
@@ -96,16 +95,16 @@ module fiber_access_dense_tb;
     .tile_en(tile_en),
     .write_scanner_addr_in(ws_addr),
     .write_scanner_addr_in_valid(ws_addr_valid),
-    .write_scanner_block_mode(1'b0),
+    .write_scanner_block_mode(1'b1),
     .write_scanner_block_wr_in(ws_blk),
     .write_scanner_block_wr_in_valid(ws_blk_valid),
     .write_scanner_compressed(1'b1),
     .write_scanner_data_in(coord_in_0),
     .write_scanner_data_in_valid(coord_in_0_valid),
     .write_scanner_init_blank(1'b0),
-    .write_scanner_lowest_level(1'b0),
+    .write_scanner_lowest_level(1'b1),
     // .write_scanner_spacc_mode(1'b0),
-    // .write_scanner_stop_lvl(16'b0),
+    .write_scanner_stop_lvl(16'b0),
     .write_scanner_tile_en(tile_en),
     .addr_to_mem(memory_addr_to_mem_p0),
     .data_to_mem(memory_0_data_in_p0),
@@ -124,16 +123,16 @@ module fiber_access_dense_tb;
     .vector_reduce_mode(vector_reduce_mode)
     );
 
-    tile_write #(
+    glb_write #(
         .FILE_NAME("coord_in_0.txt"),
         .TX_NUM(`TX_NUM_GLB),
         .RAN_SHITF(0)
     ) coord_in_0_inst (
         .clk(clk),
         .rst_n(rst_n),
-        .data(coord_in_0),
-        .ready(coord_in_0_ready),
-        .valid(coord_in_0_valid),
+        .data(ws_blk),
+        .ready(ws_blk_ready),
+        .valid(ws_blk_valid),
         .done(done[0]),
         .flush(flush)
     );

--- a/SPARSE_UNIT_TEST/fiber_access_dense_tb.sv
+++ b/SPARSE_UNIT_TEST/fiber_access_dense_tb.sv
@@ -1,0 +1,261 @@
+`timescale 1ns/1ns
+`ifndef TX_NUM_GLB
+`define TX_NUM_GLB 1
+`endif
+
+module fiber_access_dense_tb;
+
+    reg clk;
+    reg clk_en;
+    reg rst_n;
+    reg stall;
+    reg flush;
+    reg tile_en;
+    reg vector_reduce_mode; 
+    wire [63:0] cycle_count ;
+
+    // wire for dut input & output
+    wire [16:0] coord_in_0;
+    wire coord_in_0_valid;
+    wire coord_in_0_ready;
+    wire [16:0] pos_in_0;
+    wire pos_in_0_valid;
+    wire pos_in_0_ready;
+    wire [16:0] coord_out;
+    wire coord_out_valid;
+    wire coord_out_ready;
+    wire [16:0] pos_out_0;
+    wire pos_out_0_valid;
+    wire pos_out_0_ready;
+
+    // wire for mem
+    wire [63:0] memory_0_data_in_p0;
+    wire [63:0] memory_0_data_out_p0;
+    wire [8:0] memory_addr_to_mem_p0;
+    wire memory_0_read_enable_p0;
+    wire memory_0_write_enable_p0;
+
+    // dummy connection
+    wire [16:0] ws_addr;
+    wire ws_addr_valid;
+    wire ws_addr_ready;
+
+    wire [16:0] ws_blk;
+    wire ws_blk_valid;
+    wire ws_blk_ready;
+
+    wire [16:0] rs_blk;
+    wire rs_blk_valid;
+    wire rs_blk_ready;
+
+    assign {ws_addr, ws_addr_valid, ws_blk, ws_blk_valid} = 35'b0;
+    assign {rs_blk, rs_blk_valid} = 17'b0;
+
+    logic [1:0] [31:0] config_out;
+
+    wire [3:0] done;
+    parameter NUM_CYCLES = 40000;
+
+    integer clk_count;
+    integer start_write;
+    integer write_eos;
+    integer write_count;
+    logic start_read;
+    logic read_input_in;
+    integer read_count;
+    integer wait_gap = 0; // should pass with arb gap
+    integer DONE_TOKEN = 17'h10100;
+
+    fiber_access_16 dut 
+    (
+    .buffet_buffet_capacity_log({4'b1000, 4'b1000}),
+    .data_from_mem(memory_0_data_out_p0),
+    .buffet_tile_en(tile_en),
+    .clk(clk),
+    .clk_en(clk_en),
+    .flush(flush),
+    .read_scanner_block_mode(1'b0),
+    .read_scanner_block_rd_out_ready(rs_blk_ready),
+    .read_scanner_coord_out_ready(coord_out_ready),
+    .read_scanner_dense(1'b1),
+    // .read_scanner_dim_size(16'b0),
+    .read_scanner_do_repeat(1'b0),
+    .read_scanner_inner_dim_offset(16'b0),
+    .read_scanner_lookup(1'b0),
+    .read_scanner_pos_out_ready(pos_out_0_ready),
+    .read_scanner_repeat_factor(16'b0),
+    .read_scanner_repeat_outer_inner_n(1'b0),
+    .read_scanner_root(1'b0),
+    // .read_scanner_spacc_mode(1'b0),
+    // .read_scanner_stop_lvl(16'b0),
+    .read_scanner_tile_en(tile_en),
+    .read_scanner_us_pos_in(pos_in_0),
+    // .read_scanner_us_pos_in_valid(pos_in_0_valid & start_read == 1),
+    .read_scanner_us_pos_in_valid(pos_in_0_valid),
+    .rst_n(rst_n),
+    .tile_en(tile_en),
+    .write_scanner_addr_in(ws_addr),
+    .write_scanner_addr_in_valid(ws_addr_valid),
+    .write_scanner_block_mode(1'b0),
+    .write_scanner_block_wr_in(ws_blk),
+    .write_scanner_block_wr_in_valid(ws_blk_valid),
+    .write_scanner_compressed(1'b1),
+    .write_scanner_data_in(coord_in_0),
+    .write_scanner_data_in_valid(coord_in_0_valid),
+    .write_scanner_init_blank(1'b0),
+    .write_scanner_lowest_level(1'b0),
+    // .write_scanner_spacc_mode(1'b0),
+    // .write_scanner_stop_lvl(16'b0),
+    .write_scanner_tile_en(tile_en),
+    .addr_to_mem(memory_addr_to_mem_p0),
+    .data_to_mem(memory_0_data_in_p0),
+    .read_scanner_block_rd_out(rs_blk),
+    .read_scanner_block_rd_out_valid(rs_blk_valid),
+    .read_scanner_coord_out(coord_out),
+    .read_scanner_coord_out_valid(coord_out_valid),
+    .read_scanner_pos_out(pos_out_0),
+    .read_scanner_pos_out_valid(pos_out_0_valid),
+    .read_scanner_us_pos_in_ready(pos_in_0_ready),
+    .ren_to_mem(memory_0_read_enable_p0),
+    .wen_to_mem(memory_0_write_enable_p0),
+    .write_scanner_addr_in_ready(ws_addr_ready),
+    .write_scanner_block_wr_in_ready(ws_blk_ready),
+    .write_scanner_data_in_ready(coord_in_0_ready),
+    .vector_reduce_mode(vector_reduce_mode)
+    );
+
+    tile_write #(
+        .FILE_NAME("coord_in_0.txt"),
+        .TX_NUM(`TX_NUM_GLB),
+        .RAN_SHITF(0)
+    ) coord_in_0_inst (
+        .clk(clk),
+        .rst_n(rst_n),
+        .data(coord_in_0),
+        .ready(coord_in_0_ready),
+        .valid(coord_in_0_valid),
+        .done(done[0]),
+        .flush(flush)
+    );
+
+    tile_write #(
+        .FILE_NAME("pos_in_0.txt"),
+        .TX_NUM(`TX_NUM_GLB),
+        .RAN_SHITF(1)
+    ) pos_in_0_inst (
+        .clk(clk),
+        .rst_n(rst_n),
+        .data(pos_in_0),
+        // .ready(pos_in_0_ready & start_read == 1),
+        .ready(pos_in_0_ready),
+        .valid(pos_in_0_valid),
+        .done(done[1]),
+        .flush(flush)
+    );
+
+    tile_read #(
+        .FILE_NAME("coord_out.txt"),
+        .TX_NUM(`TX_NUM_GLB),
+        .RAN_SHITF(2)
+    ) coord_out_0_inst (
+        .clk(clk),
+        .rst_n(rst_n),
+        .data(coord_out),
+        .ready(coord_out_ready),
+        .valid(coord_out_valid),
+        .done(done[2]),
+        .flush(flush)
+    );
+
+    tile_read #(
+        .FILE_NAME("pos_out_0.txt"),
+        .TX_NUM(`TX_NUM_GLB),
+        .RAN_SHITF(3)
+    ) pos_out_0_inst (
+        .clk(clk),
+        .rst_n(rst_n),
+        .data(pos_out_0),
+        .ready(pos_out_0_ready),
+        .valid(pos_out_0_valid),
+        .done(done[3]),
+        .flush(flush)
+    );
+
+    sram_sp memory_0 (
+        .clk(clk),
+        .clk_en(clk_en),
+        .data_in_p0(memory_0_data_in_p0),
+        .flush(flush),
+        .read_addr_p0(memory_addr_to_mem_p0),
+        .read_enable_p0(memory_0_read_enable_p0),
+        .write_addr_p0(memory_addr_to_mem_p0),
+        .write_enable_p0(memory_0_write_enable_p0),
+        .data_out_p0(memory_0_data_out_p0)
+    );
+
+    // simulated clk signal, 10ns period
+    initial begin
+        clk_count = 0;
+        start_write = 0;
+        write_eos = 0;
+        write_count = 0;
+        start_read = 0;
+        read_input_in = 0;
+        read_count = 0;
+
+        clk = 0;
+        clk_en = 1;
+        rst_n = 0;
+        tile_en = 1;
+        vector_reduce_mode = 0;
+        flush = 0;
+
+        #5 clk = 1;
+        flush = 1;
+        rst_n = 1;
+        #5 clk = 0;
+        flush = 0;
+
+        for(integer i = 0; i < NUM_CYCLES * 2; i = i + 1) begin
+            #5 clk = ~clk;
+            
+            if (clk && pos_in_0_valid) begin
+                read_input_in = 1;
+            end
+
+            // FSM
+            if (clk && coord_in_0_valid && start_write == 0) begin
+                start_write = 1;
+            end
+            if (clk && start_write == 1 && coord_in_0 == DONE_TOKEN && coord_in_0_ready && coord_in_0_valid) begin
+                write_eos = 1;
+            end
+            if (clk && start_write == 1 && write_eos && |{coord_in_0 != DONE_TOKEN, coord_in_0_ready, coord_in_0_valid}) begin
+                write_eos = 0;
+                start_write = 2;
+            end
+
+            // DATA
+            if (clk && start_write == 1) begin
+                write_count += 1;
+            end
+
+            if (clk && start_write == 2 && wait_gap > 0) begin
+                wait_gap -= 1;
+            end
+
+            if (clk && start_write == 2 && wait_gap == 0 && start_read == 0 && read_input_in) begin
+                start_read = 1;
+            end
+
+            if (clk && start_read == 1 && ~(done[2] & done[3])) begin
+                read_count += 1;
+            end
+        end
+        $display("write cycle count: %0d", write_count);
+        $display("read cycle count: %0d", read_count);
+        $finish;
+    
+    end
+
+endmodule

--- a/SPARSE_UNIT_TEST/fiber_access_tb.sv
+++ b/SPARSE_UNIT_TEST/fiber_access_tb.sv
@@ -78,7 +78,6 @@ module fiber_access_tb;
     .read_scanner_block_rd_out_ready(rs_blk_ready),
     .read_scanner_coord_out_ready(coord_out_ready),
     .read_scanner_dense(1'b0),
-    .read_scanner_dim_size(16'b0),
     .read_scanner_do_repeat(1'b0),
     .read_scanner_inner_dim_offset(16'b0),
     .read_scanner_lookup(1'b0),

--- a/SPARSE_UNIT_TEST/test_fiber_access_dense_unit.py
+++ b/SPARSE_UNIT_TEST/test_fiber_access_dense_unit.py
@@ -1,0 +1,309 @@
+from lake.top.fiber_access import FiberAccess
+from lake.top.tech_maps import GF_Tech_Map
+import magma as m
+from magma import *
+import tempfile
+# from kratos import *
+import kratos as k
+
+
+import sparse_helper
+from sparse_helper import convert_stream_to_onyx_interp
+from sam.sim.src.base import remove_emptystr
+from sam.sim.test.test import TIMEOUT
+from sam.sim.src.rd_scanner import UncompressCrdRdScan
+from sam.sim.src.wr_scanner import CompressWrScan
+
+
+import subprocess
+import os
+import random
+random.seed(15)
+import string
+
+
+def init_module():
+    data_width = 16
+    mem_depth = 512
+    mem_width = 64
+    macro_width = 32
+    dual_port = False
+    pipeline_scanner = True
+    fiber_access = FiberAccess(data_width=16,
+                        mem_width=64,
+                        tb_harness=True,
+                        local_memory=False,
+                        tech_map=GF_Tech_Map(depth=mem_depth, width=macro_width, dual_port=dual_port),
+                        defer_fifos=False,
+                        add_flush=True,
+                        use_pipelined_scanner=pipeline_scanner,
+                        fifo_depth=2,
+                        buffet_optimize_wide=True,
+                        perf_debug=False)
+
+    k.verilog(fiber_access, filename=f"./modules/Fiber_access.sv", optimize_if=False)
+
+    sparse_helper.update_tcl("fiber_access_dense_tb")
+
+def create_random_fiber(rate, size, d, f_type = "coord", maybe = 0.0):
+    # size = int(size*random.uniform(1.0, 1.0+d))
+
+    s = int(rate*size)
+    if f_type == "coord":
+        crd = random.sample(range(size), s)
+        crd.sort()
+        return crd
+    elif f_type == "pos":
+        pos = random.sample(range(1, size + 1), s)
+        pos.sort()
+        if maybe != 0.0:
+            replace = random.sample(range(0, len(pos)), int(len(pos)*maybe))
+            for i in replace:
+                pos[i] = 'N'
+        return pos
+    else:
+        val = [random.uniform(0, 2**15-1) for i in range(s)]
+        return val
+
+def create_random(n, rate, size, d1=0, maybe = 0.0): #d1 is the num of the outer level
+    if n == 1:
+        in_crd1 = create_random_fiber(rate, size, 0.2, "coord", maybe) + ['S0', 'D']
+        return in_crd1
+    
+    elif n == 2:
+        if d1 == 0:
+            d1 = int(random.uniform(2, int(size**(1/2))))
+        d2 = size // d1
+        rate = rate**(1/2)
+        ret = []
+        for i in range(d1):
+            ret_t = []
+            if random.random() < rate:
+                ret_t = ret_t + create_random_fiber(rate, d2, 0.2, "coord", maybe)
+            if i == d1 - 1:
+                ret = ret + ret_t + ['S1', 'D']
+            else:
+                ret = ret + ret_t + ['S0']
+        return ret
+    elif n == 3:
+        if d1 == 0:
+            d1 = int(random.uniform(2, int(size**(1/3))))
+        d2 = size // d1
+        d1_ = int(random.uniform(2, int(d2**(1/2))))
+        rate = rate**(1/3)
+        ret = []
+        for i in range(d1):
+            ret_t = []
+            if random.random() < rate:
+                ret_t = create_random(2, rate*rate, d2, d1_)
+            else:
+                ret_t = ret_t + ['S1', 'D']
+
+            if i == d1 - 1:
+                ret = ret + ret_t[:-2] + ['S2', 'D']
+            else:
+                ret = ret + ret_t[:-1]
+        return ret
+
+
+def create_ref(coord, dim, rate, size, maybe = False):
+    ran = []
+    k = 0
+    for i in coord:
+        if sparse_helper.is_STOP_sam(i):
+            ran.append(k)
+            k += 1
+    if maybe:
+        ran.append('N')
+    t = create_random(dim, rate, size)
+    for j in range(len(t)):
+        if type(t[j]) is int:
+            t[j] = ran[int(random.uniform(0, len(ran)))]
+    return t
+
+
+def create_gold(dim_size, in_ref):
+    dim_size_cpy = dim_size
+    i_r_cpy = in_ref[:]
+
+    print(i_r_cpy)
+    print(dim_size_cpy)
+
+    done = False
+    time = 0
+
+    crdscan = UncompressCrdRdScan(dim=dim_size_cpy)
+    done = False
+    time = 0
+    out_crd = []
+    out_ref = []
+
+    while not done and time < TIMEOUT:
+        if len(in_ref) > 0:
+            crdscan.set_in_ref(in_ref.pop(0))
+
+        crdscan.update()
+
+        out_crd.append(crdscan.out_crd())
+        out_ref.append(crdscan.out_ref())
+
+        done = crdscan.done
+        time += 1
+
+    print("sam read cycle count: ", time)
+    
+    out_crd = remove_emptystr(out_crd)
+    out_ref = remove_emptystr(out_ref)
+
+    out_c = []
+    out_r = []
+    for i in range(len(out_crd)):
+        if out_crd[i] != 'N':
+            out_c.append(out_crd[i])
+            out_r.append(out_ref[i])
+    # now encode the dim size to (2, 0, dim_size) data pair
+    encoded_dim_size = [2, 0, dim_size_cpy]
+    st = [encoded_dim_size, i_r_cpy, out_c, out_r]
+    tr_st = [convert_stream_to_onyx_interp(i) for i in st]
+
+    return tr_st
+
+
+def load_test_module(test_name):
+    if test_name == "basic_2d":
+        dim_size = 10
+        in_ref = [0, 1, 'S0', 0, 1, 2, 'D']
+        return create_gold(dim_size, in_ref)
+    
+    elif test_name == "basic_1d":
+        dim_size = 6
+        in_ref = [0, 1, 'S1', 'D']
+        return create_gold(dim_size, in_ref)
+
+    # test case 
+    elif test_name == "rd_full_mat_scan_1d":
+        t_arg = test_name.split("_")
+        dim_size = random.randint(1, 30)
+        num_fiber = random.randint(1, 30)
+        in_ref = []
+        for i in range(0, num_fiber):
+            in_ref.append(i)
+        in_ref.append("S0")
+        in_ref.append("D")
+        return create_gold(dim_size, in_ref)
+
+        
+    elif test_name[0:2] == "rd":
+        t_arg = test_name.split("_")
+        dim1 = int(t_arg[1][0])
+        rate1 = float(t_arg[2])
+        size1 = int(t_arg[3]) # unlike other tests, the size here is the final size
+        t_size = int(size1 / rate1)
+
+        use_root = False
+        dim2 = 0
+        if t_arg[4] == 'root':
+            use_root = True
+        
+        if not use_root:
+            dim2 = int(t_arg[4][0])
+        rate2 = float(t_arg[5])
+        size2 = int(t_arg[6])
+        coord = sparse_helper.coord_drop(create_random(dim1, rate1, t_size))
+
+        coord_t = coord[:] #only used for seq
+
+        ref = create_ref(coord, 1, 1.0, 2)
+        if use_root:
+            ref = [i for i in ref if not sparse_helper.is_STOP_sam(i)]
+        else:
+            ref = create_ref(coord, dim2, rate2, size2)
+        [ic, ir, gc, gr] = create_gold(coord, ref)
+        
+        if len(t_arg[0]) == 3:
+            ref = create_ref(coord_t, 1, 1.0, 2)
+            if use_root:
+                ref = [i for i in ref if not sparse_helper.is_STOP_sam(i)]
+            else:
+                ref = create_ref(coord_t, dim2, rate2, size2)
+            [ic1, ir1, gc1, gr1] = create_gold(coord_t, ref)
+            ic += ic1
+            ir += ir1
+            gc += gc1
+            gr += gr1
+        return [ic, ir, gc, gr]
+
+    else:
+        in_crd = [0, 'S0', 'D']
+        in_ref = [0, 0, 0, 'D']
+        return create_gold(in_crd, in_ref)
+
+
+def module_iter_basic(test_name, add_test=""):
+    [ic, ir, gc, gr] = load_test_module(test_name)
+
+    if add_test != "" and add_test != "void":
+        additional_t = load_test_module(add_test)
+        ic = ic + additional_t[0]
+        ir = ir + additional_t[1]
+        gc = gc + additional_t[2]
+        gr = gr + additional_t[3]
+
+    print(ic)
+    print(ir)
+    print(gc)
+    print(gr)
+
+    sparse_helper.write_txt("coord_in_0.txt", ic)
+    sparse_helper.write_txt("pos_in_0.txt", ir)
+
+    sparse_helper.clear_txt("coord_out.txt")
+    sparse_helper.clear_txt("pos_out_0.txt")
+
+    #run command "make sim" to run the simulation
+    if add_test == "":
+        sim_result = subprocess.run(["make", "sim", "TEST_TAR=fiber_access_dense_tb.sv", "TOP=fiber_access_dense_tb",\
+                             "TEST_UNIT=Fiber_access.sv"], capture_output=True, text=True)
+    else:
+        sim_result = subprocess.run(["make", "sim", "TEST_TAR=fiber_access_dense_tb.sv",\
+                             "TOP=fiber_access_dense_tb", "TX_NUM_GLB=2", "TEST_UNIT=Fiber_access.sv"\
+                             ], capture_output=True, text=True)
+    output = sim_result.stdout
+    # print(output)
+    cycle_count_line = output[output.find("write cycle count:"):]
+    lines = cycle_count_line.splitlines()
+    print(lines[0])
+    #print(lines[1])
+
+    coord_out = sparse_helper.read_txt("coord_out.txt", addit=add_test != "")
+    pos_out_0 = sparse_helper.read_txt("pos_out_0.txt", addit=add_test != "")
+    # print(coord_out)
+    # print(pos_out_0)
+
+    #compare each element in the output from coord_out.txt with the gold output
+    assert len(coord_out) == len(gc), \
+        f"Output length {len(coord_out)} didn't match gold length {len(gc)}"
+    for i in range(len(coord_out)):
+        assert coord_out[i] == gc[i], \
+            f"Output {coord_out[i]} didn't match gold {gc[i]} at index {i}"
+    
+    #compare each element in the output from pos_out_0.txt with the gold output
+    assert len(pos_out_0) == len(gr), \
+        f"Output length {len(pos_out_0)} didn't match gold length {len(gr)}"
+    for i in range(len(pos_out_0)):
+        assert pos_out_0[i] == gr[i], \
+            f"Output {pos_out_0[i]} didn't match gold {gr[i]} at index {i}"
+    
+    print(test_name, " passed\n")
+
+
+def test_iter_basic():
+    init_module()
+    test_list = ["basic_1d", "basic_2d"]
+    for test in test_list:
+        module_iter_basic(test)
+
+def test_rd_full_mat_scan_1d():
+    init_module()
+    for i in range(0, 10):
+        module_iter_basic("rd_full_mat_scan_1d")

--- a/SPARSE_UNIT_TEST/test_fiber_access_dense_unit.py
+++ b/SPARSE_UNIT_TEST/test_fiber_access_dense_unit.py
@@ -45,9 +45,7 @@ def init_module():
 
     sparse_helper.update_tcl("fiber_access_dense_tb")
 
-def create_random_fiber(rate, size, d, maybe = 0.0):
-    # size = int(size*random.uniform(1.0, 1.0+d))
-
+def create_random_fiber(rate, size, maybe = 0.0):
     s = int(rate*size)
     pos = random.sample(range(0, size + 1), s)
     pos.sort()
@@ -57,7 +55,7 @@ def create_random_fiber(rate, size, d, maybe = 0.0):
             pos[i] = 'N'
     return pos
 
-def create_random(n, rate, size, d1=0, maybe = 0.0): #d1 is the num of the outer level
+def create_random(n, rate, size, d1=0, maybe=0.0): #d1 is the num of the outer level
     if n == 1:
         in_crd1 = create_random_fiber(rate, size, maybe) + ['S0', 'D']
         return in_crd1
@@ -87,7 +85,7 @@ def create_random(n, rate, size, d1=0, maybe = 0.0): #d1 is the num of the outer
         for i in range(d1):
             ret_t = []
             if random.random() < rate:
-                ret_t = create_random(2, rate*rate, d2, d1_)
+                ret_t = create_random(2, rate*rate, d2, d1_, maybe)
             else:
                 ret_t = ret_t + ['S1', 'D']
 
@@ -121,6 +119,9 @@ def create_gold(dim_size, in_ref, root=False):
     dim_size_cpy = dim_size
     i_r_cpy = in_ref[:]
 
+    print(dim_size_cpy)
+    print(i_r_cpy)
+
     done = False
     time = 0
 
@@ -143,7 +144,7 @@ def create_gold(dim_size, in_ref, root=False):
         time += 1
 
     print("sam read cycle count: ", time)
-    
+
     out_crd = remove_emptystr(out_crd)
     out_ref = remove_emptystr(out_ref)
 
@@ -176,7 +177,6 @@ def load_test_module(test_name, root=False):
         dim_size = 20
         in_ref = ['S0', 'S0', 1, 0, 'S0', 'S0', 1, 'S1', 'D']
         return create_gold(dim_size, in_ref)
-
     # test case 
     elif test_name == "rd_full_mat_scan":
         t_arg = test_name.split("_")
@@ -194,6 +194,25 @@ def load_test_module(test_name, root=False):
         rate = random.uniform(0, 1)
         size = random.randint(1, 30)
         in_ref = create_random(n, rate, size)
+        return create_gold(dim_size, in_ref)
+    elif test_name == "maybe_token_1":
+        dim_size = 10
+        in_ref = [0, 'N', 'S0', 'N', 'N', 2, 'D']
+        return create_gold(dim_size, in_ref)
+    elif test_name == "maybe_token_2":
+        dim_size = 20
+        in_ref = ['N', 'S0', 1, 'N', 'S0', 'N', 'S1', 'D']
+        return create_gold(dim_size, in_ref)
+    elif test_name == "maybe_token_3":
+        dim_size = 30
+        in_ref = ['S0', 'S0', 'N', 'N', 'S0', 'S0', 1, 'N', 'S1', 'D']
+        return create_gold(dim_size, in_ref)
+    elif test_name == "rd_pos_input_maybe":
+        dim_size = random.randint(1, 30)
+        n = random.randint(1, 3)
+        size = random.randint(3, 30)
+        maybe = random.uniform(0.5, 0.8)
+        in_ref = create_random(n, 1.0, size, maybe=maybe)
         return create_gold(dim_size, in_ref)
     elif test_name == "test_root_basic":
         dim_size = random.randint(1, 30)
@@ -286,21 +305,33 @@ def test_rd_pos_input():
     for i in range(0, 10):
         module_iter_basic("rd_pos_input")
 
+def test_maybe():
+    init_module()
+    test_list = ["maybe_token_1", "maybe_token_2", "maybe_token_3"]
+    for test in test_list:
+        module_iter_basic(test)
+
+def test_rd_pos_input_maybe():
+    init_module()
+    for i in range(0, 10):
+        module_iter_basic("rd_pos_input_maybe")
+
+def test_root_basic():
+    init_module()
+    for i in range(0, 10):
+        module_iter_basic("test_root_basic", root=True)
+
+def test_root_basic_seq():
+    init_module()
+    for i in range(0, 10):
+        module_iter_basic("test_root_basic", "test_root_basic", root=True)
+
 def test_seq_rd():
     init_module()
-    test_list = ["basic_1d", "basic_2d", "rd_full_mat_scan", "rd_pos_input", "in_ref_empty_fiber"]
+    test_list = ["basic_1d", "basic_2d", "rd_full_mat_scan", "rd_pos_input", "maybe_token_1", "maybe_token_2", "maybe_token_3",
+                 "in_ref_empty_fiber", "rd_pos_input_maybe", "test_root_basic"]
     for i in range(0, 20):
         random_test_cases = []
         random_test_cases.append(random.choice(test_list))
         random_test_cases.append(random.choice(test_list))
         module_iter_basic(random_test_cases[0], random_test_cases[1])
-
-def test_root_basic():
-    init_module()
-    for i in range(0, 20):
-        module_iter_basic("test_root_basic", root=True)
-
-def test_root_basic_seq():
-    init_module()
-    for i in range(0, 20):
-        module_iter_basic("test_root_basic", "test_root_basic", root=True)

--- a/SPARSE_UNIT_TEST/test_fiber_access_dense_unit.py
+++ b/SPARSE_UNIT_TEST/test_fiber_access_dense_unit.py
@@ -172,6 +172,11 @@ def load_test_module(test_name):
         in_ref = [0, 1, 'S1', 'D']
         return create_gold(dim_size, in_ref)
 
+    elif test_name == "in_ref_empty_fiber":
+        dim_size = 20
+        in_ref = ['S0', 'S0', 1, 0, 'S0', 'S0', 1, 'S1', 'D']
+        return (create_gold(dim_size, in_ref))
+
     # test case 
     elif test_name == "rd_full_mat_scan":
         t_arg = test_name.split("_")
@@ -260,7 +265,25 @@ def test_rd_full_mat_scan():
     for i in range(0, 10):
         module_iter_basic("rd_full_mat_scan")
 
+def test_seq_basic():
+    init_module()
+    module_iter_basic("basic_1d", "basic_2d")
+
+def test_empty_fiber():
+    init_module()
+    module_iter_basic("in_ref_empty_fiber")
+    
+
 def test_rd_pos_input():
     init_module()
     for i in range(0, 10):
         module_iter_basic("rd_pos_input")
+
+def test_seq_rd():
+    init_module()
+    test_list = ["basic_1d", "basic_2d", "rd_full_mat_scan", "rd_pos_input", "in_ref_empty_fiber"]
+    for i in range(0, 20):
+        random_test_cases = []
+        random_test_cases.append(random.choice(test_list))
+        random_test_cases.append(random.choice(test_list))
+        module_iter_basic(random_test_cases[0], random_test_cases[1])

--- a/SPARSE_UNIT_TEST/test_fiber_access_unit.py
+++ b/SPARSE_UNIT_TEST/test_fiber_access_unit.py
@@ -428,57 +428,57 @@ def test_iter_basic():
         module_iter_basic(test)
 
 
-# def test_random_1d_1d():
-#     init_module()
-#     test_list = ["rd_1d_0.1_200_1d_1.0_3", "rd_1d_0.3_200_1d_1.0_3", "rd_1d_0.5_200_1d_1.0_3", "rd_1d_0.8_200_1d_1.0_3", "rd_1d_1.0_200_1d_1.0_3"]
-#     for test in test_list:
-#         module_iter_basic(test)
+def test_random_1d_1d():
+    init_module()
+    test_list = ["rd_1d_0.1_200_1d_1.0_3", "rd_1d_0.3_200_1d_1.0_3", "rd_1d_0.5_200_1d_1.0_3", "rd_1d_0.8_200_1d_1.0_3", "rd_1d_1.0_200_1d_1.0_3"]
+    for test in test_list:
+        module_iter_basic(test)
 
 
-# def test_random_1d_root():
-#     init_module()
-#     test_list = ["rd_1d_0.1_200_root_1.0_3", "rd_1d_0.3_200_root_1.0_3", "rd_1d_0.5_200_root_1.0_3", "rd_1d_0.8_200_root_1.0_3", "rd_1d_1.0_200_root_1.0_3"]
-#     for test in test_list:
-#         module_iter_basic(test)
+def test_random_1d_root():
+    init_module()
+    test_list = ["rd_1d_0.1_200_root_1.0_3", "rd_1d_0.3_200_root_1.0_3", "rd_1d_0.5_200_root_1.0_3", "rd_1d_0.8_200_root_1.0_3", "rd_1d_1.0_200_root_1.0_3"]
+    for test in test_list:
+        module_iter_basic(test)
 
 
-# def test_random_2d_1d():
-#     init_module()
-#     test_list = ["rd_2d_0.1_100_1d_1.0_3", "rd_2d_0.3_100_1d_1.0_3", "rd_2d_0.5_100_1d_1.0_3", "rd_2d_0.8_100_1d_1.0_3", "rd_2d_1.0_100_1d_1.0_3"]
-#     for test in test_list:
-#         module_iter_basic(test)
+def test_random_2d_1d():
+    init_module()
+    test_list = ["rd_2d_0.1_100_1d_1.0_3", "rd_2d_0.3_100_1d_1.0_3", "rd_2d_0.5_100_1d_1.0_3", "rd_2d_0.8_100_1d_1.0_3", "rd_2d_1.0_100_1d_1.0_3"]
+    for test in test_list:
+        module_iter_basic(test)
 
 
-# def test_random_2d_2d():
-#     init_module()
-#     test_list = ["rd_2d_0.1_100_2d_0.3_30", "rd_2d_0.3_100_2d_0.3_30", "rd_2d_0.5_100_2d_0.3_30", "rd_2d_0.8_100_2d_0.3_30", "rd_2d_1.0_100_2d_0.3_30"]
-#     for test in test_list:
-#         module_iter_basic(test)
+def test_random_2d_2d():
+    init_module()
+    test_list = ["rd_2d_0.1_100_2d_0.3_30", "rd_2d_0.3_100_2d_0.3_30", "rd_2d_0.5_100_2d_0.3_30", "rd_2d_0.8_100_2d_0.3_30", "rd_2d_1.0_100_2d_0.3_30"]
+    for test in test_list:
+        module_iter_basic(test)
 
 
-# def test_seq1():
-#     init_module()
-#     module_iter_basic("empty_root_seq_3", "empty_root_seq_4")
-#     module_iter_basic("seq_1_1", "seq_1_2")
+def test_seq1():
+    init_module()
+    module_iter_basic("empty_root_seq_3", "empty_root_seq_4")
+    module_iter_basic("seq_1_1", "seq_1_2")
 
 
-# def test_seq2():
-#     init_module()
-#     test_list = ["rdS_1d_0.1_50_1d_1.0_3", "rdS_1d_0.3_50_1d_1.0_3", "rdS_1d_0.5_50_1d_1.0_3", "rdS_1d_0.8_50_1d_1.0_3", "rdS_1d_1.0_50_1d_1.0_3"] +\
-#                 ["rdS_1d_0.1_50_root_1.0_3", "rdS_1d_0.3_50_root_1.0_3", "rdS_1d_0.5_50_root_1.0_3", "rdS_1d_0.8_50_root_1.0_3", "rdS_1d_1.0_50_root_1.0_3"] +\
-#                 ["rdS_2d_0.1_100_1d_1.0_3", "rdS_2d_0.3_100_1d_1.0_3", "rdS_2d_0.5_100_1d_1.0_3", "rdS_2d_0.8_100_1d_1.0_3", "rdS_2d_1.0_100_1d_1.0_3"] +\
-#                 ["rdS_2d_0.1_100_2d_0.3_30", "rdS_2d_0.3_100_2d_0.3_30", "rdS_2d_0.5_100_2d_0.3_30", "rdS_2d_0.8_100_2d_0.3_30", "rdS_2d_1.0_100_2d_0.3_30"]
-#     for test in test_list:
-#         module_iter_basic(test, add_test="void")
+def test_seq2():
+    init_module()
+    test_list = ["rdS_1d_0.1_50_1d_1.0_3", "rdS_1d_0.3_50_1d_1.0_3", "rdS_1d_0.5_50_1d_1.0_3", "rdS_1d_0.8_50_1d_1.0_3", "rdS_1d_1.0_50_1d_1.0_3"] +\
+                ["rdS_1d_0.1_50_root_1.0_3", "rdS_1d_0.3_50_root_1.0_3", "rdS_1d_0.5_50_root_1.0_3", "rdS_1d_0.8_50_root_1.0_3", "rdS_1d_1.0_50_root_1.0_3"] +\
+                ["rdS_2d_0.1_100_1d_1.0_3", "rdS_2d_0.3_100_1d_1.0_3", "rdS_2d_0.5_100_1d_1.0_3", "rdS_2d_0.8_100_1d_1.0_3", "rdS_2d_1.0_100_1d_1.0_3"] +\
+                ["rdS_2d_0.1_100_2d_0.3_30", "rdS_2d_0.3_100_2d_0.3_30", "rdS_2d_0.5_100_2d_0.3_30", "rdS_2d_0.8_100_2d_0.3_30", "rdS_2d_1.0_100_2d_0.3_30"]
+    for test in test_list:
+        module_iter_basic(test, add_test="void")
 
 
-# def test_seq3():
-#     init_module()
-#     test_list =  ["rd_1d_0.1_200_1d_1.0_3", "rd_1d_0.3_200_1d_1.0_3", "rd_1d_0.5_200_1d_1.0_3", "rd_1d_0.8_200_1d_1.0_3", "rd_1d_1.0_200_1d_1.0_3"] +\
-#                  ["rd_1d_0.1_200_root_1.0_3", "rd_1d_0.3_200_root_1.0_3", "rd_1d_0.5_200_root_1.0_3", "rd_1d_0.8_200_root_1.0_3", "rd_1d_1.0_200_root_1.0_3"] +\
-#                  ["rd_2d_0.1_100_1d_1.0_3", "rd_2d_0.3_100_1d_1.0_3", "rd_2d_0.5_100_1d_1.0_3", "rd_2d_0.8_100_1d_1.0_3", "rd_2d_1.0_100_1d_1.0_3"] +\
-#                  ["rd_2d_0.1_100_2d_0.3_30", "rd_2d_0.3_100_2d_0.3_30", "rd_2d_0.5_100_2d_0.3_30", "rd_2d_0.8_100_2d_0.3_30", "rd_2d_1.0_100_2d_0.3_30"] +\
-#                  ["direct_1d", "direct_2d", "in_ref_2d_1", "in_ref_2d_2", "in_ref_empty_fiber", "maybe_token", "arr_1", "arr_2", "arr_3", "xxx"]
-#     for i in range(30):
-#         rand = random.sample(test_list, 2)
-#         module_iter_basic(rand[0], rand[1])
+def test_seq3():
+    init_module()
+    test_list =  ["rd_1d_0.1_200_1d_1.0_3", "rd_1d_0.3_200_1d_1.0_3", "rd_1d_0.5_200_1d_1.0_3", "rd_1d_0.8_200_1d_1.0_3", "rd_1d_1.0_200_1d_1.0_3"] +\
+                 ["rd_1d_0.1_200_root_1.0_3", "rd_1d_0.3_200_root_1.0_3", "rd_1d_0.5_200_root_1.0_3", "rd_1d_0.8_200_root_1.0_3", "rd_1d_1.0_200_root_1.0_3"] +\
+                 ["rd_2d_0.1_100_1d_1.0_3", "rd_2d_0.3_100_1d_1.0_3", "rd_2d_0.5_100_1d_1.0_3", "rd_2d_0.8_100_1d_1.0_3", "rd_2d_1.0_100_1d_1.0_3"] +\
+                 ["rd_2d_0.1_100_2d_0.3_30", "rd_2d_0.3_100_2d_0.3_30", "rd_2d_0.5_100_2d_0.3_30", "rd_2d_0.8_100_2d_0.3_30", "rd_2d_1.0_100_2d_0.3_30"] +\
+                 ["direct_1d", "direct_2d", "in_ref_2d_1", "in_ref_2d_2", "in_ref_empty_fiber", "maybe_token", "arr_1", "arr_2", "arr_3", "xxx"]
+    for i in range(30):
+        rand = random.sample(test_list, 2)
+        module_iter_basic(rand[0], rand[1])

--- a/SPARSE_UNIT_TEST/test_fiber_access_unit.py
+++ b/SPARSE_UNIT_TEST/test_fiber_access_unit.py
@@ -422,62 +422,63 @@ def module_iter_basic(test_name, add_test=""):
 
 def test_iter_basic():
     init_module()
-    test_list = ["direct_1d", "direct_2d", "in_ref_2d_1", "in_ref_2d_2", "in_ref_empty_fiber", "maybe_token", "arr_1", "arr_2", "arr_3", "xxx"]
+    # test_list = ["direct_1d", "direct_2d", "in_ref_2d_1", "in_ref_2d_2", "in_ref_empty_fiber", "maybe_token", "arr_1", "arr_2", "arr_3", "xxx"]
+    test_list = ["direct_1d"]
     for test in test_list:
         module_iter_basic(test)
 
 
-def test_random_1d_1d():
-    init_module()
-    test_list = ["rd_1d_0.1_200_1d_1.0_3", "rd_1d_0.3_200_1d_1.0_3", "rd_1d_0.5_200_1d_1.0_3", "rd_1d_0.8_200_1d_1.0_3", "rd_1d_1.0_200_1d_1.0_3"]
-    for test in test_list:
-        module_iter_basic(test)
+# def test_random_1d_1d():
+#     init_module()
+#     test_list = ["rd_1d_0.1_200_1d_1.0_3", "rd_1d_0.3_200_1d_1.0_3", "rd_1d_0.5_200_1d_1.0_3", "rd_1d_0.8_200_1d_1.0_3", "rd_1d_1.0_200_1d_1.0_3"]
+#     for test in test_list:
+#         module_iter_basic(test)
 
 
-def test_random_1d_root():
-    init_module()
-    test_list = ["rd_1d_0.1_200_root_1.0_3", "rd_1d_0.3_200_root_1.0_3", "rd_1d_0.5_200_root_1.0_3", "rd_1d_0.8_200_root_1.0_3", "rd_1d_1.0_200_root_1.0_3"]
-    for test in test_list:
-        module_iter_basic(test)
+# def test_random_1d_root():
+#     init_module()
+#     test_list = ["rd_1d_0.1_200_root_1.0_3", "rd_1d_0.3_200_root_1.0_3", "rd_1d_0.5_200_root_1.0_3", "rd_1d_0.8_200_root_1.0_3", "rd_1d_1.0_200_root_1.0_3"]
+#     for test in test_list:
+#         module_iter_basic(test)
 
 
-def test_random_2d_1d():
-    init_module()
-    test_list = ["rd_2d_0.1_100_1d_1.0_3", "rd_2d_0.3_100_1d_1.0_3", "rd_2d_0.5_100_1d_1.0_3", "rd_2d_0.8_100_1d_1.0_3", "rd_2d_1.0_100_1d_1.0_3"]
-    for test in test_list:
-        module_iter_basic(test)
+# def test_random_2d_1d():
+#     init_module()
+#     test_list = ["rd_2d_0.1_100_1d_1.0_3", "rd_2d_0.3_100_1d_1.0_3", "rd_2d_0.5_100_1d_1.0_3", "rd_2d_0.8_100_1d_1.0_3", "rd_2d_1.0_100_1d_1.0_3"]
+#     for test in test_list:
+#         module_iter_basic(test)
 
 
-def test_random_2d_2d():
-    init_module()
-    test_list = ["rd_2d_0.1_100_2d_0.3_30", "rd_2d_0.3_100_2d_0.3_30", "rd_2d_0.5_100_2d_0.3_30", "rd_2d_0.8_100_2d_0.3_30", "rd_2d_1.0_100_2d_0.3_30"]
-    for test in test_list:
-        module_iter_basic(test)
+# def test_random_2d_2d():
+#     init_module()
+#     test_list = ["rd_2d_0.1_100_2d_0.3_30", "rd_2d_0.3_100_2d_0.3_30", "rd_2d_0.5_100_2d_0.3_30", "rd_2d_0.8_100_2d_0.3_30", "rd_2d_1.0_100_2d_0.3_30"]
+#     for test in test_list:
+#         module_iter_basic(test)
 
 
-def test_seq1():
-    init_module()
-    module_iter_basic("empty_root_seq_3", "empty_root_seq_4")
-    module_iter_basic("seq_1_1", "seq_1_2")
+# def test_seq1():
+#     init_module()
+#     module_iter_basic("empty_root_seq_3", "empty_root_seq_4")
+#     module_iter_basic("seq_1_1", "seq_1_2")
 
 
-def test_seq2():
-    init_module()
-    test_list = ["rdS_1d_0.1_50_1d_1.0_3", "rdS_1d_0.3_50_1d_1.0_3", "rdS_1d_0.5_50_1d_1.0_3", "rdS_1d_0.8_50_1d_1.0_3", "rdS_1d_1.0_50_1d_1.0_3"] +\
-                ["rdS_1d_0.1_50_root_1.0_3", "rdS_1d_0.3_50_root_1.0_3", "rdS_1d_0.5_50_root_1.0_3", "rdS_1d_0.8_50_root_1.0_3", "rdS_1d_1.0_50_root_1.0_3"] +\
-                ["rdS_2d_0.1_100_1d_1.0_3", "rdS_2d_0.3_100_1d_1.0_3", "rdS_2d_0.5_100_1d_1.0_3", "rdS_2d_0.8_100_1d_1.0_3", "rdS_2d_1.0_100_1d_1.0_3"] +\
-                ["rdS_2d_0.1_100_2d_0.3_30", "rdS_2d_0.3_100_2d_0.3_30", "rdS_2d_0.5_100_2d_0.3_30", "rdS_2d_0.8_100_2d_0.3_30", "rdS_2d_1.0_100_2d_0.3_30"]
-    for test in test_list:
-        module_iter_basic(test, add_test="void")
+# def test_seq2():
+#     init_module()
+#     test_list = ["rdS_1d_0.1_50_1d_1.0_3", "rdS_1d_0.3_50_1d_1.0_3", "rdS_1d_0.5_50_1d_1.0_3", "rdS_1d_0.8_50_1d_1.0_3", "rdS_1d_1.0_50_1d_1.0_3"] +\
+#                 ["rdS_1d_0.1_50_root_1.0_3", "rdS_1d_0.3_50_root_1.0_3", "rdS_1d_0.5_50_root_1.0_3", "rdS_1d_0.8_50_root_1.0_3", "rdS_1d_1.0_50_root_1.0_3"] +\
+#                 ["rdS_2d_0.1_100_1d_1.0_3", "rdS_2d_0.3_100_1d_1.0_3", "rdS_2d_0.5_100_1d_1.0_3", "rdS_2d_0.8_100_1d_1.0_3", "rdS_2d_1.0_100_1d_1.0_3"] +\
+#                 ["rdS_2d_0.1_100_2d_0.3_30", "rdS_2d_0.3_100_2d_0.3_30", "rdS_2d_0.5_100_2d_0.3_30", "rdS_2d_0.8_100_2d_0.3_30", "rdS_2d_1.0_100_2d_0.3_30"]
+#     for test in test_list:
+#         module_iter_basic(test, add_test="void")
 
 
-def test_seq3():
-    init_module()
-    test_list =  ["rd_1d_0.1_200_1d_1.0_3", "rd_1d_0.3_200_1d_1.0_3", "rd_1d_0.5_200_1d_1.0_3", "rd_1d_0.8_200_1d_1.0_3", "rd_1d_1.0_200_1d_1.0_3"] +\
-                 ["rd_1d_0.1_200_root_1.0_3", "rd_1d_0.3_200_root_1.0_3", "rd_1d_0.5_200_root_1.0_3", "rd_1d_0.8_200_root_1.0_3", "rd_1d_1.0_200_root_1.0_3"] +\
-                 ["rd_2d_0.1_100_1d_1.0_3", "rd_2d_0.3_100_1d_1.0_3", "rd_2d_0.5_100_1d_1.0_3", "rd_2d_0.8_100_1d_1.0_3", "rd_2d_1.0_100_1d_1.0_3"] +\
-                 ["rd_2d_0.1_100_2d_0.3_30", "rd_2d_0.3_100_2d_0.3_30", "rd_2d_0.5_100_2d_0.3_30", "rd_2d_0.8_100_2d_0.3_30", "rd_2d_1.0_100_2d_0.3_30"] +\
-                 ["direct_1d", "direct_2d", "in_ref_2d_1", "in_ref_2d_2", "in_ref_empty_fiber", "maybe_token", "arr_1", "arr_2", "arr_3", "xxx"]
-    for i in range(30):
-        rand = random.sample(test_list, 2)
-        module_iter_basic(rand[0], rand[1])
+# def test_seq3():
+#     init_module()
+#     test_list =  ["rd_1d_0.1_200_1d_1.0_3", "rd_1d_0.3_200_1d_1.0_3", "rd_1d_0.5_200_1d_1.0_3", "rd_1d_0.8_200_1d_1.0_3", "rd_1d_1.0_200_1d_1.0_3"] +\
+#                  ["rd_1d_0.1_200_root_1.0_3", "rd_1d_0.3_200_root_1.0_3", "rd_1d_0.5_200_root_1.0_3", "rd_1d_0.8_200_root_1.0_3", "rd_1d_1.0_200_root_1.0_3"] +\
+#                  ["rd_2d_0.1_100_1d_1.0_3", "rd_2d_0.3_100_1d_1.0_3", "rd_2d_0.5_100_1d_1.0_3", "rd_2d_0.8_100_1d_1.0_3", "rd_2d_1.0_100_1d_1.0_3"] +\
+#                  ["rd_2d_0.1_100_2d_0.3_30", "rd_2d_0.3_100_2d_0.3_30", "rd_2d_0.5_100_2d_0.3_30", "rd_2d_0.8_100_2d_0.3_30", "rd_2d_1.0_100_2d_0.3_30"] +\
+#                  ["direct_1d", "direct_2d", "in_ref_2d_1", "in_ref_2d_2", "in_ref_empty_fiber", "maybe_token", "arr_1", "arr_2", "arr_3", "xxx"]
+#     for i in range(30):
+#         rand = random.sample(test_list, 2)
+#         module_iter_basic(rand[0], rand[1])

--- a/SPARSE_UNIT_TEST/test_fiber_access_unit.py
+++ b/SPARSE_UNIT_TEST/test_fiber_access_unit.py
@@ -422,8 +422,7 @@ def module_iter_basic(test_name, add_test=""):
 
 def test_iter_basic():
     init_module()
-    # test_list = ["direct_1d", "direct_2d", "in_ref_2d_1", "in_ref_2d_2", "in_ref_empty_fiber", "maybe_token", "arr_1", "arr_2", "arr_3", "xxx"]
-    test_list = ["direct_1d"]
+    test_list = ["direct_1d", "direct_2d", "in_ref_2d_1", "in_ref_2d_2", "in_ref_empty_fiber", "maybe_token", "arr_1", "arr_2", "arr_3", "xxx"]
     for test in test_list:
         module_iter_basic(test)
 

--- a/SPARSE_UNIT_TEST/value_tb.sv
+++ b/SPARSE_UNIT_TEST/value_tb.sv
@@ -77,7 +77,6 @@ module value_tb;
     .read_scanner_block_rd_out_ready(rs_blk_ready),
     .read_scanner_coord_out_ready(coord_out_ready),
     .read_scanner_dense(1'b0),
-    .read_scanner_dim_size(16'b0),
     .read_scanner_do_repeat(1'b0),
     .read_scanner_inner_dim_offset(16'b0),
     .read_scanner_lookup(1'b1),

--- a/lake/modules/scanner_pipe.py
+++ b/lake/modules/scanner_pipe.py
@@ -2049,7 +2049,6 @@ class ScannerPipe(MemoryController):
     def get_config_mode_str(self):
         return "read_scanner"
 
-    # def get_bitstream(self, inner_offset, max_out, ranges, strides, root, do_repeat=0, repeat_outer=0, repeat_factor=0, stop_lvl=0, block_mode=0, lookup=0):
     def get_bitstream(self, config_kwargs):
 
         flattened = create_wrapper_flatten(self.internal_generator.clone(),
@@ -2063,12 +2062,9 @@ class ScannerPipe(MemoryController):
         do_repeat = config_kwargs['do_repeat']
         repeat_outer = config_kwargs['repeat_outer']
         repeat_factor = config_kwargs['repeat_factor']
-        # stop_lvl = config_kwargs['stop_lvl']
         block_mode = config_kwargs['block_mode']
         lookup = config_kwargs['lookup']
         dense = config_kwargs['dense']
-        dim_size = config_kwargs['dim_size']
-        # spacc_mode = config_kwargs['spacc_mode']
 
         # Store all configurations here
         config = [
@@ -2082,7 +2078,6 @@ class ScannerPipe(MemoryController):
             ('lookup', lookup),
             ('root', root),
             ('dense', dense),
-            ('dim_size', dim_size),
             # ('spacc_mode', spacc_mode),
             ('tile_en', 1)]
 
@@ -2091,11 +2086,6 @@ class ScannerPipe(MemoryController):
             tform_ranges, tform_strides = transform_strides_and_ranges(ranges=ranges,
                                                                        strides=strides,
                                                                        dimensionality=dim)
-            # for i in range(dim):
-            #     config += [("fiber_outer_iter_dimensionality", dim)]
-            #     config += [(f"fiber_outer_iter_ranges_{i}", tform_ranges[i])]
-            #     config += [(f"fiber_outer_addr_strides_{i}", tform_strides[i])]
-            #     config += [("fiber_outer_addr_starting_addr", 0)]
 
         return trim_config_list(flattened, config)
 
@@ -2108,10 +2098,6 @@ if __name__ == "__main__":
                               add_clk_enable=True,
                               perf_debug=True,
                               split_mem_requests=False)
-
-    # Lift config regs and generate annotation
-    # lift_config_reg(pond_dut.internal_generator)
-    # extract_formal_annotation(pond_dut, "pond.txt")
 
     verilog(scanner_dut, filename="scanner_pipe.sv",
             optimize_if=False)

--- a/lake/modules/scanner_pipe.py
+++ b/lake/modules/scanner_pipe.py
@@ -1109,8 +1109,7 @@ class ScannerPipe(MemoryController):
         #######
         # READ
         #######
-        # The dimension size pair is stored in addr 0 and 1 in dense mode
-        READ.output(self._seg_addr_out_to_fifo, kts.ternary(self._readout_loop | self._dense, 0, self._infifo_pos_in))
+        READ.output(self._seg_addr_out_to_fifo, kts.ternary(self._readout_loop, 0, self._infifo_pos_in))
         READ.output(self._seg_op_out_to_fifo, 1)
         READ.output(self._seg_ID_out_to_fifo, 0)
         # Only request a push when there's valid, non-eos data on the fifo
@@ -1139,9 +1138,7 @@ class ScannerPipe(MemoryController):
         #######
         # READ_ALT
         #######
-        # The dimension size pair is stored in addr 0 and 1 in dense mode
-        # TODO: this may be wrong in the case of tile pipelining
-        READ_ALT.output(self._seg_addr_out_to_fifo, kts.ternary(self._readout_loop | self._dense, 1, self._infifo_pos_in_d1 + 1))
+        READ_ALT.output(self._seg_addr_out_to_fifo, kts.ternary(self._readout_loop, 1, self._infifo_pos_in_d1 + 1))
         READ_ALT.output(self._seg_op_out_to_fifo, 1)
         READ_ALT.output(self._seg_ID_out_to_fifo, 0)
         READ_ALT.output(self._seg_req_push, ~self._seg_res_fifo_full)

--- a/lake/modules/scanner_pipe.py
+++ b/lake/modules/scanner_pipe.py
@@ -62,10 +62,6 @@ class ScannerPipe(MemoryController):
         self._dense = self.input("dense", 1)
         self._dense.add_attribute(ConfigRegAttr("This scanner is 'scanning' a dense data structure..."))
 
-        # Dimension Size
-        self._dim_size = self.input("dim_size", 16)
-        self._dim_size.add_attribute(ConfigRegAttr("This scanner is 'scanning' a dense data structure of this size..."))
-
         # Repeat number
         self._do_repeat = self.input("do_repeat", 1)
         self._do_repeat.add_attribute(ConfigRegAttr("If this scanner should do a repeat for creating outer coords"))
@@ -83,16 +79,6 @@ class ScannerPipe(MemoryController):
 
         self._lookup_mode = self.input("lookup", 1)
         self._lookup_mode.add_attribute(ConfigRegAttr("Random access/lookup mode...."))
-
-        # Set the stop token injection level - (default 0 + 1 for root)
-        # self._stop_lvl = self.input("stop_lvl", 16)
-        # self._stop_lvl.add_attribute(ConfigRegAttr("What level stop tokens should this scanner inject/In sparse accum mode, when to pop the data blocks"))
-
-        # self._stop_lvl_spill = self.input("stop_lvl_spill", 16)
-        # self._stop_lvl_spill.add_attribute(ConfigRegAttr("What level stop tokens should this scanner inject/In sparse accum mode, when to pop the data blocks"))
-
-        # self._spacc_mode = self.input("spacc_mode", 1)
-        # self._spacc_mode.add_attribute(ConfigRegAttr("Sparse accum mode"))
 
         # Vector Reduce Mode
         self._vector_reduce_mode = self.input("vector_reduce_mode", 1)
@@ -136,18 +122,6 @@ class ScannerPipe(MemoryController):
 
         self._block_rd_out_ready_in = self.input("block_rd_out_ready", 1)
         self._block_rd_out_ready_in.add_attribute(ControlSignalAttr(is_control=True))
-
-        # Eos for both streams...
-        # self._eos_out = self.output("eos_out", 2)
-        # self._eos_out.add_attribute(ControlSignalAttr(is_control=False))
-
-        # Valid out for both streams
-        # self._valid_out = self.output("valid_out", 2)
-        # self._valid_out.add_attribute(ControlSignalAttr(is_control=False))
-
-        # Ready in for pos and coord
-        # self._ready_in = self.input("ready_in", 2)
-        # self._ready_in.add_attribute(ControlSignalAttr(is_control=True))
 
         ################################################################################
         # TO BUFFET
@@ -196,76 +170,8 @@ class ScannerPipe(MemoryController):
             self._ID_out_valid_out = [self.output(f"ID_out_{i}_valid", 1) for i in range(num_ports)]
             [self._ID_out_valid_out[i].add_attribute(ControlSignalAttr(is_control=False, full_bus=False)) for i in range(num_ports)]
 
-        #     for i in range(num_ports):
-        #         self._addr_out.append()
-
-        #         self._addr_out_ready_in.append()
-
-        #         self._addr_out_valid_out.append()
-
-        #         # OP out r/v
-        #         self._op_out.append()
-
-        #         self._op_out_ready_in.append()
-
-        #         self._op_out_valid_out.append()
-
-        #         # Response channel from buffet
-        #         self._rd_rsp_data_in.append()
-
-        #         self._rd_rsp_valid_in.append()
-        #         self._rd_rsp_ready_out.append()
-
-        # else:
-        #     self._addr_out = self.output("addr_out", self.data_width + 1, explicit_array=True, packed=True)
-        #     self._addr_out.add_attribute(ControlSignalAttr(is_control=False, full_bus=True))
-
-        #     self._addr_out_ready_in = self.input("addr_out_ready", 1)
-        #     self._addr_out_ready_in.add_attribute(ControlSignalAttr(is_control=True, full_bus=False))
-
-        #     self._addr_out_valid_out = self.output("addr_out_valid", 1)
-        #     self._addr_out_valid_out.add_attribute(ControlSignalAttr(is_control=False, full_bus=False))
-
-        #     # OP out r/v
-        #     self._op_out = self.output("op_out", self.data_width + 1, explicit_array=True, packed=True)
-        #     self._op_out.add_attribute(ControlSignalAttr(is_control=False, full_bus=True))
-
-        #     self._op_out_ready_in = self.input("op_out_ready", 1)
-        #     self._op_out_ready_in.add_attribute(ControlSignalAttr(is_control=True, full_bus=False))
-
-        #     self._op_out_valid_out = self.output("op_out_valid", 1)
-        #     self._op_out_valid_out.add_attribute(ControlSignalAttr(is_control=False, full_bus=False))
-
-        #     # ID out r/v
-        #     self._ID_out = self.output("ID_out", self.data_width + 1, explicit_array=True, packed=True)
-        #     self._ID_out.add_attribute(ControlSignalAttr(is_control=False, full_bus=True))
-
-        #     self._ID_out_ready_in = self.input("ID_out_ready", 1)
-        #     self._ID_out_ready_in.add_attribute(ControlSignalAttr(is_control=True, full_bus=False))
-
-        #     self._ID_out_valid_out = self.output("ID_out_valid", 1)
-        #     self._ID_out_valid_out.add_attribute(ControlSignalAttr(is_control=False, full_bus=False))
-
-        #     # Response channel from buffet
-        #     self._rd_rsp_data_in = self.input("rd_rsp_data_in", self.data_width + 1, explicit_array=True, packed=True)
-        #     self._rd_rsp_data_in.add_attribute(ControlSignalAttr(is_control=False, full_bus=True))
-
-        #     self._rd_rsp_valid_in = self.input("rd_rsp_data_in_valid", 1)
-        #     self._rd_rsp_valid_in.add_attribute(ControlSignalAttr(is_control=True))
-
-        #     self._rd_rsp_ready_out = self.output("rd_rsp_data_in_ready", 1)
-        #     self._rd_rsp_ready_out.add_attribute(ControlSignalAttr(is_control=False))
-
-        # Intermediate for typing...
-        # self._ren = self.var("ren", 1)
-
         # Point to the row in storage for data recovery
         self._payload_ptr = self.var("payload_ptr", self.data_width)
-        # self._payload_ptr.add_attribute(ControlSignalAttr(is_control=False, full_bus=True))
-
-        # self.wire(self._addr_out[0][self.data_width + 1 - 1], kts.const(0, 1))
-        # self.wire(self._op_out[0][self.data_width + 1 - 1], kts.const(0, 1))
-        # self.wire(self._ID_out[0][self.data_width + 1 - 1], kts.const(0, 1))
 
 # ==========================================
 # Generate addresses to scan over fiber...
@@ -278,7 +184,6 @@ class ScannerPipe(MemoryController):
         self._inc_rep = self.var("inc_rep", 1)
         self._clr_rep = self.var("clr_rep", 1)
         self._num_reps = add_counter(self, "num_reps", 16, self._inc_rep, self._clr_rep)
-        # self._step_agen = self.var("step_agen", 1)
 
 # =============================
 # Input FIFO
@@ -337,29 +242,12 @@ class ScannerPipe(MemoryController):
 
         self._us_fifo_push = self.var("us_fifo_push", 1)
 
-        # self._non_vr_mode_us_pos_fifo_eos_in = self.var("non_vr_mode_us_pos_fifo_eos_in", 1)
-        # self._non_vr_mode_us_pos_fifo_data_in = self.var("non_vr_mode_us_pos_fifo_data_in", 16)
-        # self._non_vr_mode_us_pos_fifo_push = self.var("non_vr_mode_us_pos_fifo_push", 1)
-
-        # self.wire(self._non_vr_mode_us_pos_fifo_eos_in, kts.ternary(self._root, self._us_fifo_inject_eos, self._upstream_pos_in[self.data_width]))
-        # self.wire(self._non_vr_mode_us_pos_fifo_data_in, kts.ternary(self._root, self._us_fifo_inject_data, self._upstream_pos_in[self.data_width - 1, 0]))
-        # self.wire(self._non_vr_mode_us_pos_fifo_push, kts.ternary(self._root, self._us_fifo_inject_push, self._upstream_valid_in))
-
-        # indicate valid data as well
-        # self.wire(self._pos_in_us_packed[2 * self.data_width + 2 - 1, self.data_width + 2], self._upstream_coord_in)
-        # self.wire(self._pos_in_us_packed[self.data_width + 1], self._upstream_valid_in)
-
         # The EOS tags on the last valid in the stream
-        # self.wire(self._pos_in_us_packed[self.data_width], kts.ternary(self._vector_reduce_mode, self._pos_to_read_scanner_from_vr_fsm[self.data_width], self._non_vr_mode_us_pos_fifo_eos_in))
         self.wire(self._pos_in_us_packed[self.data_width], kts.ternary(self._root, self._us_fifo_inject_eos, self._upstream_pos_in[self.data_width]))
-        # self.wire(self._pos_in_us_packed[self.data_width - 1, 0], kts.ternary(self._vector_reduce_mode, self._pos_to_read_scanner_from_vr_fsm[self.data_width - 1, 0], self._non_vr_mode_us_pos_fifo_data_in))
         self.wire(self._pos_in_us_packed[self.data_width - 1, 0], kts.ternary(self._root, self._us_fifo_inject_data, self._upstream_pos_in[self.data_width - 1, 0]))
-        # self.wire(self._us_fifo_push, kts.ternary(self._vector_reduce_mode, self._pos_valid_to_read_scanner_from_vr_fsm, self._non_vr_mode_us_pos_fifo_push))
         self.wire(self._us_fifo_push, kts.ternary(self._root, self._us_fifo_inject_push, self._upstream_valid_in))
 
         self._data_out_us_packed = self.var("fifo_out_us_packed", 1 * self.data_width + 1, packed=True)
-        # self.wire(self._infifo_coord_in, self._data_out_us_packed[2 * self.data_width + 2 - 1, self.data_width + 2])
-        # self.wire(self._infifo_valid_in, self._data_out_us_packed[self.data_width + 1])
         self.wire(self._infifo_eos_in, self._data_out_us_packed[self.data_width])
         self.wire(self._infifo_pos_in, self._data_out_us_packed[self.data_width - 1, 0])
 
@@ -386,16 +274,6 @@ class ScannerPipe(MemoryController):
         self.wire(self._upstream_ready_out, ~self._fifo_us_full)
 
         self.wire(self._infifo_valid_in, ~self._infifo.ports.empty)
-
-        # @always_ff((posedge, "clk"), (negedge, "rst_n"))
-        # def eos_seen_ff():
-        #     if ~self._rst_n:
-        #         self._eos_in_seen = 0
-        #     elif self._infifo_eos_in:
-        #         self._eos_in_seen = 1
-        # self.add_code(eos_seen_ff)
-
-        # Read Response FIFO
 
 # =============================
 # Input FIFOS from BUFFET
@@ -903,8 +781,6 @@ class ScannerPipe(MemoryController):
         self.wire(self._fifo_full, self._fifo_full_pre.r_or())
 
         self._data_to_fifo = self.var("data_to_fifo", self.data_width)
-        # Gate ready after last read in the stream
-        # self._ready_gate = self.var("ready_gate", 1)
 
         # Define logic for iter_finish + rep_finish
         self._iter_finish = sticky_flag(self, self._last_valid_accepting, clear=self._clr_fiber_addr, name="iter_finish")
@@ -924,20 +800,15 @@ class ScannerPipe(MemoryController):
         self._maybe_in = self.var("maybe_in", 1)
         self.wire(self._maybe_in, self._infifo_eos_in & self._infifo_valid_in & (self._infifo_pos_in[9, 8] == kts.const(2, 2)))
 
-        # self._seg_stop_lvl_geq = self.var("seg_stop_lvl_geq", 1)
-        # self.wire(self._seg_stop_lvl_geq, self._seg_res_fifo_fill_data_in[16] & (self._seg_res_fifo_fill_data_in[self.OPCODE_BT] == self.STOP_CODE) &
-        #                               (self._seg_res_fifo_fill_data_in[self.STOP_BT] >= self._stop_lvl[self.STOP_BT]))
-
-        # # This indicates we should go into the readout loop
-        # self._seg_stop_lvl_geq_p1 = self.var("seg_stop_lvl_geq_p1", 1)
-        # self.wire(self._seg_stop_lvl_geq_p1, self._seg_res_fifo_fill_data_in[16] & (self._seg_res_fifo_fill_data_in[self.OPCODE_BT] == self.STOP_CODE) &
-        #                               (self._seg_res_fifo_fill_data_in[self.STOP_BT] >= (self._stop_lvl[self.STOP_BT] + 1)))
-
-        # self._seg_stop_lvl_geq_p1_sticky = sticky_flag(self, self._seg_stop_lvl_geq_p1 & self._seg_res_fifo_push_alloc & self._seg_res_fifo_push_fill,
-        #                                                clear=self._clr_readout_loop_seg, name="go_to_readout_sticky")
-
-        self._infifo_pos_in_d1_en = self.var("infifo_pos_in_d1_en", 1)
-        self._infifo_pos_in_d1 = register(self, self._infifo_pos_in, enable=self._infifo_pos_in_d1_en)
+        ####### Logic for dense scanning
+        # counter for generating the dense coordinate and bookkeeping for inserting stop token
+        self._inc_dense_scan_cnt = self.var("inc_dense_scan_cnt", 1)
+        self._clr_dense_scan_cnt = self.var("clr_dense_scan_cnt", 1)
+        self._dense_scan_cnt = add_counter(self, name="dense_scan_cnt", bitwidth=16, increment=self._inc_dense_scan_cnt, clear=self._clr_dense_scan_cnt)
+        # register for storing the dimension size of the dense matrix
+        self._dim_size_reg_en = self.var("dim_size_reg_en", 1)
+        self._dim_size_reg = register(self, self._seg_res_fifo_data_out[0][self.data_width - 1, 0], enable=self._dim_size_reg_en)
+        
 
         ####### Logic for block reads
         self._inc_req_made_seg = self.var("inc_req_made_seg", 1)
@@ -1194,7 +1065,6 @@ class ScannerPipe(MemoryController):
         INJECT_ROUTING.output(self._us_fifo_inject_push, 1)
         INJECT_ROUTING.output(self._seg_res_fifo_push_alloc, ~self._seg_res_fifo_full)
         INJECT_ROUTING.output(self._seg_res_fifo_push_fill, ~self._seg_res_fifo_full)
-        # INJECT_0.output(self._seg_res_fifo_push_reserve, 0)
         INJECT_ROUTING.output(self._seg_res_fifo_fill_data_in, kts.concat(kts.const(1, 1), kts.const(0, 6), kts.const(3, 2), kts.const(0, 7), self._readout_loop))
 
         #######
@@ -1204,7 +1074,6 @@ class ScannerPipe(MemoryController):
         READ.output(self._seg_op_out_to_fifo, 1)
         READ.output(self._seg_ID_out_to_fifo, 0)
         # Only request a push when there's valid, non-eos data on the fifo
-        # READ.output(self._seg_req_push, self._infifo_valid_in & ~self._infifo_eos_in & ~self._seg_res_fifo_full & ~self._dense)
         READ.output(self._seg_req_push, ((self._infifo_valid_in & ~self._infifo_eos_in & ~self._dense) | self._readout_loop) & ~self._seg_res_fifo_full)
         # Can pop the infifo if we have done or are in dense mode
         # READ.output(self._seg_pop_infifo, (((self._done_in | (self._dense & self._infifo_valid_in & ~self._eos_in)) & ~self._seg_res_fifo_full) | self._maybe_in) & ~self._readout_loop)

--- a/lake/modules/scanner_pipe.py
+++ b/lake/modules/scanner_pipe.py
@@ -964,10 +964,10 @@ class ScannerPipe(MemoryController):
         READ.output(self._us_fifo_inject_push, 0)
         # Only push through the done in READ, in conjunction with the fill pulse
         READ.output(self._seg_res_fifo_push_alloc, kts.ternary(self._done_in | self._dense,
-                                                               ~self._seg_res_fifo_full & self._infifo_valid_in & ~self._eos_in,
+                                                               ~self._seg_res_fifo_full & self._infifo_valid_in & ~self._eos_in & ~self._maybe_in,
                                                                (~self._seg_res_fifo_full & self._any_seg_grant_push) & ~self._maybe_in))
         # Only fill if we have done_in
-        READ.output(self._seg_res_fifo_push_fill, (self._done_in | (self._dense & self._infifo_valid_in & ~self._eos_in)) & ~self._seg_res_fifo_full)
+        READ.output(self._seg_res_fifo_push_fill, (self._done_in | (self._dense & self._infifo_valid_in & ~self._eos_in & ~self._maybe_in)) & ~self._seg_res_fifo_full)
         READ.output(self._seg_res_fifo_fill_data_in, kts.concat(self._infifo_eos_in, self._infifo_pos_in))
         READ.output(self._infifo_pos_in_d1_en, self._any_seg_grant_push & ~self._seg_res_fifo_full)
 

--- a/lake/modules/scanner_pipe.py
+++ b/lake/modules/scanner_pipe.py
@@ -745,9 +745,6 @@ class ScannerPipe(MemoryController):
         # register for storing the dimension size of the dense matrix
         self._dim_size_reg_en = self.var("dim_size_reg_en", 1)
         self._dim_size = register(self, self._seg_res_fifo_data_out[1][self.data_width - 1, 0], enable=self._dim_size_reg_en)
-        # sticky flag that indicates whether dim size register has been set
-        self._clr_dim_size_set = self.var("clr_dim_size_set", 1)
-        self._dim_size_reg_set = sticky_flag(self, self._dim_size_reg_en, name="dim_size_reg_set", clear=self._clr_dim_size_set, seq_only=True)
         
         # Hold state for iterator - just length
         @always_ff((posedge, "clk"), (negedge, "rst_n"))
@@ -1345,7 +1342,6 @@ class ScannerPipe(MemoryController):
         self.scan_fsm_crd.output(self._pos_out_to_fifo)
         # Only use for DENSE_STRM
         self.scan_fsm_crd.output(self._dim_size_reg_en, default=kts.const(0, 1))
-        self.scan_fsm_crd.output(self._clr_dim_size_set, default=kts.const(0, 1))
         self.scan_fsm_crd.output(self._crd_out_to_fifo)
         self.scan_fsm_crd.output(self._inc_req_made_crd)
         self.scan_fsm_crd.output(self._clr_req_made_crd)
@@ -1791,7 +1787,6 @@ class ScannerPipe(MemoryController):
         DONE_CRD.output(self._clr_req_made_crd, 1)
         DONE_CRD.output(self._inc_req_rec_crd, 0)
         DONE_CRD.output(self._clr_req_rec_crd, 1)
-        DONE_CRD.output(self._clr_dim_size_set, 1)
         DONE_CRD.output(self._crd_res_fifo_push_alloc, 0)
         DONE_CRD.output(self._crd_res_fifo_push_fill, 0)
         DONE_CRD.output(self._ptr_reg_en, 0)


### PR DESCRIPTION
**The following describe the workflow of the updated dense scanner**
1. If the scanner is in dense mode, after reset, a pair of segment request is first injected straight in to the buffet (infifo is bypassed) to retrieve the dimension size of the matrix encoded in a (0, dim_size) pair.
2. After the request is serviced, the dim size response from the memory tile is stored in a register to generate output coordinate and reference streams.
3. After finish scanning the current fiber tree (i.e., seeing a done token), the FSMs traverses back to the initial state and get ready to read the next fiber tree from the memory tile to support tile pipelining. 
4. Update how maybe token is handled in the dense mode, previously it propagates the maybe token to the output. After the update, the maybe token is no longer propagated, only a stop token is emitted.

**The followings are the changes to the scanner_pip RTL to realized the functionality:**
1. Removed commented and dead code (there's a lot).
2. Removed the "dim_size" configuration port since dim_size will now be supplied via GLB instead of config.
3. Added an additional register for buffering the dim_size read from the SRAM
5. Added two additional states to the seg FSMthat are responsible for injecting the pair of segment request that retrieve the dimension size.
6. Added an additional state to the crd FSM that handles storing the dim size response into the dim size register.
7. Added state transition for both FSMs to allow the scanner to loop back to the initial state after it has finished processing the current fiber tree. 
8. Update the seg FSM such that it only allocate space in the segment reservation fifo if the input reference is not a maybe token.

**The followings are the changes to the sparse unit test to test the updated scanner:**
1. Added dedicated pytest script and systemverilog testbench for testing the scanner in dense mode. The testcases covers simple 1d, 2d lookups, full matrix scans, random reference inputs with empty fibers, back to back input streams, maybe token input reference streams, and scanning in root mode.
2. Updated the sparse unit test Makefile so we can specify from the pytest script whether the scanner is set to root mode or not.
3. Remove the read_scanner_dim_size configuration port connection from the sparse scanner testbench (since the port is removed in the RTL).

