### PR TITLE
Vr unroll fix

### DIFF
--- a/lake/modules/buffet_like.py
+++ b/lake/modules/buffet_like.py
@@ -187,6 +187,7 @@ class BuffetLike(MemoryController):
         # Read block base and bounds...
         self._blk_base = self.var("blk_base", self.data_width, size=self.num_ID, explicit_array=True, packed=True)
         self._blk_bounds = self.var("blk_bounds", self.data_width, size=self.num_ID, explicit_array=True, packed=True)
+        self._blk_bounds_align = self.var("blk_bounds_align", self.subword_addr_bits, size=self.num_ID, explicit_array=True, packed=True)
 
         self._wen_full = self.var("wen_full", self.num_ID)
 
@@ -354,6 +355,7 @@ class BuffetLike(MemoryController):
         self._clr_curr_bounds = self.var("clr_curr_bounds", self.num_ID)
         self._curr_bounds = [register(self, self._wr_addr_fifo_out_data + 1, enable=self._en_curr_bounds[i], clear=self._clr_curr_bounds[i],
                                       name=f"curr_bounds_{i}", packed=True) for i in range(self.num_ID)]
+        self._curr_bounds_align = self.var("curr_bounds_align", self.subword_addr_bits, size=self.num_ID, explicit_array=True, packed=True)
 
         self._en_curr_base = self.var("en_curr_base", self.num_ID)
         self._first_base_set = [sticky_flag(self, self._en_curr_base[idx_], name=f"first_base_set_{idx_}", seq_only=True) for idx_ in range(self.num_ID)]
@@ -993,7 +995,8 @@ class BuffetLike(MemoryController):
         self._blk_full = self.var("blk_full", self.num_ID)
 
         self._curr_capacity_pre = self.var("curr_capacity_pre", self.data_width, size=self.num_ID, explicit_array=True, packed=True)
-        # self._curr_capacity = self.var("curr_capacity", self.data_width, size=self.num_ID, explicit_array=True, packed=True) 
+        # self._curr_capacity = self.var("curr_capacity", self.data_width, size=self.num_ID, explicit_array=True, packed=True)
+        [self.wire(self._curr_bounds_align[i], (kts.const(self.fw_int, width=self.subword_addr_bits + 1) - kts.concat(kts.const(0, 1), self._curr_bounds[i][self.subword_addr_bits - 1, 0]))[self.subword_addr_bits - 1, 0]) for i in range(self.num_ID)]
 
         @always_ff((posedge, self._clk), (negedge, self._rst_n))
         def cap_reg(self, idx):
@@ -1002,13 +1005,11 @@ class BuffetLike(MemoryController):
             # Only update when pushed or popped
             elif self._push_blk[idx] or self._pop_blk[idx]:
                 self._curr_capacity_pre[idx] = self._curr_capacity_pre[idx] + kts.ternary(self._push_blk[idx],
-                                                                                        #   self._blk_bounds[idx],
-                                                                                          self._curr_bounds[idx] + kts.concat(kts.const(0, width=self.data_width - self.subword_addr_bits), 
-                                                                                                                              (kts.const(self.fw_int, width=self.subword_addr_bits + 1)\
-                                                                                                                               - kts.concat(kts.const(0, 1), self._curr_bounds[idx][self.subword_addr_bits - 1, 0]))[self.subword_addr_bits - 1, 0]),
-                                                                                          kts.const(0, width=self.data_width)) - kts.ternary(self._pop_blk[idx],
-                                                                                                                                             self._blk_bounds[idx],
-                                                                                                                                             kts.const(0, width=self.data_width))
+                                                                                        self._curr_bounds[idx] + kts.concat(kts.const(0, width=self.data_width - self.subword_addr_bits), self._curr_bounds_align[idx]),
+                                                                                                        kts.const(0, width=self.data_width)) - kts.ternary(self._pop_blk[idx],
+                                                                                                                                                            self._blk_bounds[idx] +\
+                                                                                                                                                            + kts.concat(kts.const(0, width=self.data_width - self.subword_addr_bits), self._blk_bounds_align[idx]),
+                                                                                                                                                            kts.const(0, width=self.data_width))
 
         [self.add_code(cap_reg, idx=i) for i in range(self.num_ID)]
 
@@ -1378,7 +1379,7 @@ class BuffetLike(MemoryController):
 
             for i in range(self.num_ID):
                 ### Bookkeeping FIFO
-                blk_fifo_in = kts.concat(self._curr_base[i], self._curr_bounds[i])
+                blk_fifo_in = kts.concat(self._curr_base[i], self._curr_bounds[i], self._curr_bounds_align[i])
                 blk_fifo = RegFIFO(data_width=blk_fifo_in.width, width_mult=1, depth=self.fifo_depth, defer_hrdwr_gen=False)
 
                 self.add_child(f"blk_fifo_{i}",
@@ -1389,7 +1390,7 @@ class BuffetLike(MemoryController):
                             push=self._push_blk[i],
                             pop=self._pop_blk[i],
                             data_in=blk_fifo_in,
-                            data_out=kts.concat(self._blk_base[i], self._blk_bounds[i]))  # added empty control signal
+                            data_out=kts.concat(self._blk_base[i], self._blk_bounds[i], self._blk_bounds_align[i]))  # added empty control signal
 
                 self.wire(self._blk_full[i], blk_fifo.ports.full)
                 self.wire(self._blk_valid[i], ~blk_fifo.ports.empty)

--- a/lake/modules/intersect.py
+++ b/lake/modules/intersect.py
@@ -512,8 +512,8 @@ class Intersect(MemoryController):
         # CHANGE 4
         # PASS_DONE.output(self._pop_fifo[0], (self._coord_in_fifo_valid_in[0] & (self._coord_in_fifo_in[0] == self._done_token)))
         # PASS_DONE.output(self._pop_fifo[1], (self._coord_in_fifo_valid_in[1] & (self._coord_in_fifo_in[1] == self._done_token)))
-        PASS_DONE.output(self._pop_fifo[0], (valid_concat.r_and() & (self._coord_in_fifo_in[0] == self._done_token)))
-        PASS_DONE.output(self._pop_fifo[1], (valid_concat.r_and() & (self._coord_in_fifo_in[1] == self._done_token)))
+        PASS_DONE.output(self._pop_fifo[0], (~self._fifo_full.r_or() & valid_concat.r_and() & (self._coord_in_fifo_in[0] == self._done_token)))
+        PASS_DONE.output(self._pop_fifo[1], (~self._fifo_full.r_or() & valid_concat.r_and() & (self._coord_in_fifo_in[1] == self._done_token)))
         # CHANGE 3
         # PASS_DONE.output(self._fifo_push, ~self._fifo_full.r_or())
         PASS_DONE.output(self._fifo_push, ~self._fifo_full.r_or() & valid_concat.r_and())


### PR DESCRIPTION
1. Fix bug in fiber_access where read is issued too early and not waiting until the done token shows up 
2. Fix bug in buffet where it hangs if the highest address of the address space is accessed
3. Fix bug in union where input fifo pops prematurely without checking for down stream fifo availability, causing data loss
4. Fix buffet data alignment bug in block mode.