### PR TITLE
Configurable non-empty PE FIFOs

### DIFF
--- a/lake/modules/reg_fifo_cfg.py
+++ b/lake/modules/reg_fifo_cfg.py
@@ -8,7 +8,7 @@ class RegFIFO_cfg(Generator):
     This module generates register-based FIFOs. These are useful
     when we only need a few entries with no prefetching needed
 
-    This version can be configured to be initialized non-empty 
+    This version can be configured to be initialized non-empty
     '''
     def __init__(self,
                  data_width,
@@ -192,7 +192,8 @@ class RegFIFO_cfg(Generator):
 
     @always_comb
     def valid_comb(self):
-        self._valid = ((~self._empty) | self._passthru)
+        self._valid = ((~self._empty & ~self._flush & self._clk_en) | self._passthru)
+        # self._valid = ((~self._empty) | self._passthru)
         # self._valid = self._pop & ((~self._empty) | self._passthru)
 
     @always_ff((posedge, "clk"), (negedge, "rst_n"))
@@ -283,7 +284,8 @@ class RegFIFO_cfg(Generator):
 
             self._num_items = self.var("num_items", clog2(self.depth) + 1)
             # self.wire(self._full, (self._wr_ptr + 1) == self._rd_ptr)
-            self.wire(self._full, self._num_items == self.depth)
+            # self.wire(self._full, self._num_items == self.depth)
+            self.wire(self._full, (self._num_items == self.depth) | self._flush | ~self._clk_en)
             # Experiment to cover latency
             assert self.depth > 1 or self.width_mult > 1, "FIFO depth or width_mult needs to be larger than 1"
             self.wire(self._almost_full, self._num_items >= (self.depth - self.almost_full_diff))
@@ -322,8 +324,8 @@ class RegFIFO_cfg(Generator):
 
     def get_hardware_genned(self):
         return self.hardware_genned
-    
-      
+
+
 
 if __name__ == "__main__":
     # dut = RegFIFO_cfg(data_width=16,

--- a/lake/modules/reg_fifo_cfg.py
+++ b/lake/modules/reg_fifo_cfg.py
@@ -1,0 +1,341 @@
+from kratos import *
+from lake.utils.util import increment, decrement
+from lake.attributes.config_reg_attr import ConfigRegAttr
+
+
+class RegFIFO_cfg(Generator):
+    '''
+    This module generates register-based FIFOs. These are useful
+    when we only need a few entries with no prefetching needed
+
+    This version can be configured to be initialized non-empty 
+    '''
+    def __init__(self,
+                 data_width,
+                 width_mult,
+                 depth,
+                 parallel=False,
+                 break_out_rd_ptr=False,
+                 almost_full_diff=2,
+                 defer_hrdwr_gen=False,
+                 mod_name_suffix="",
+                 min_depth=0):
+
+        self.depth = depth
+        self.data_width = data_width
+        self.almost_full_diff = almost_full_diff
+        self.mod_name_suffix = mod_name_suffix
+
+        super().__init__(f"cfg_reg_fifo_depth_{self.depth}_w_{self.data_width}_afd_{self.almost_full_diff}{self.mod_name_suffix}",
+                         debug=True)
+
+        self.update_name()
+
+        #  We want to handle flush and clk_en ourselves
+        self.sync_reset_no_touch = True
+        self.clk_en_no_touch = True
+
+        # self.data_width = self.parameter("data_width", 16)
+        # self.data_width.value = data_width
+        self.width_mult = width_mult
+        self.parallel = parallel
+        self.break_out_rd_ptr = break_out_rd_ptr
+        self.defer_hrdwr_gen = defer_hrdwr_gen
+        self.min_depth = min_depth
+        self.hardware_genned = False
+
+        # Allow fifo to get depth 0
+        assert not (depth & (depth - 1)) or depth == 0, "FIFO depth needs to be a power of 2"
+
+        # CLK and RST
+        self._clk = self.clock("clk")
+        self._rst_n = self.reset("rst_n")
+        self._clk_en = self.input("clk_en", 1)
+        self._flush = self.input("flush", 1)
+        self._bogus_init_num = self.input("bogus_init_num", 2)
+
+        # INPUTS
+        self._data_in = self.input("data_in",
+                                   self.data_width,
+                                   size=self.width_mult,
+                                   explicit_array=True,
+                                   packed=True)
+        self._data_out = self.output("data_out",
+                                     self.data_width,
+                                     size=self.width_mult,
+                                     explicit_array=True,
+                                     packed=True)
+
+        # This won't work with deferred hardware gen
+        if self.parallel:
+            assert not self.defer_hrdwr_gen, "Deferred hardware generation unsupported in parallel mode"
+            self._parallel_load = self.input("parallel_load", 1)
+            self._parallel_read = self.input("parallel_read", 1)
+            self._num_load = self.input("num_load", clog2(self.depth) + 1)
+            self._parallel_in = self.input("parallel_in",
+                                           self.data_width,
+                                           size=(self.depth,
+                                                 self.width_mult),
+                                           explicit_array=True,
+                                           packed=True)
+
+            self._parallel_out = self.output("parallel_out",
+                                             self.data_width,
+                                             size=(self.depth,
+                                                   self.width_mult),
+                                             explicit_array=True,
+                                             packed=True)
+
+        self._push = self.input("push", 1)
+        self._pop = self.input("pop", 1)
+        self._valid = self.output("valid", 1)
+        self._empty = self.output("empty", 1)
+        self._full = self.output("full", 1)
+        self._almost_full = self.output("almost_full", 1)
+
+        self.ptr_width = max(1, clog2(self.depth))
+
+        if self.break_out_rd_ptr:
+            assert not self.defer_hrdwr_gen, "Deferred hardware generation unsupported in break out mode"
+            self._rd_ptr_out = self.output("rd_ptr_out", self.ptr_width)
+
+        if self.defer_hrdwr_gen is False:
+            self.generate_hardware()
+
+    @always_ff((posedge, "clk"), (negedge, "rst_n"))
+    def rd_ptr_ff(self):
+        if ~self._rst_n:
+            self._rd_ptr = 0
+        elif self._flush:
+            self._rd_ptr = 0
+        elif self._clk_en:
+            if self._read:
+                self._rd_ptr = self._rd_ptr + 1
+
+    @always_ff((posedge, "clk"), (negedge, "rst_n"))
+    def rd_ptr_ff_parallel(self):
+        if ~self._rst_n:
+            self._rd_ptr = 0
+        elif self._flush:
+            self._rd_ptr = 0
+        elif self._clk_en:
+            if self._parallel_load | self._parallel_read:
+                self._rd_ptr = 0
+            elif self._read:
+                self._rd_ptr = self._rd_ptr + 1
+
+    @always_ff((posedge, "clk"), (negedge, "rst_n"))
+    def wr_ptr_ff(self):
+        if ~self._rst_n:
+            self._wr_ptr = 0
+        elif self._flush:
+            self._wr_ptr = resize(self._bogus_init_num, self._wr_ptr.width)
+        elif self._clk_en:
+            if self._write:
+                if self._wr_ptr == (self.depth - 1):
+                    self._wr_ptr = 0
+                else:
+                    self._wr_ptr = self._wr_ptr + 1
+
+    @always_ff((posedge, "clk"), (negedge, "rst_n"))
+    def wr_ptr_ff_parallel(self):
+        if ~self._rst_n:
+            self._wr_ptr = 0
+        elif self._flush:
+            self._wr_ptr = resize(self._bogus_init_num, self._wr_ptr.width)
+        elif self._clk_en:
+            if self._parallel_load:
+                self._wr_ptr = self._num_load[max(1, clog2(self.depth)) - 1, 0]
+            elif self._parallel_read:
+                if self._push:
+                    self._wr_ptr = 1
+                else:
+                    self._wr_ptr = 0
+            elif self._write:
+                self._wr_ptr = self._wr_ptr + 1
+                # if self._wr_ptr == (self.depth - 1):
+                #     self._wr_ptr = 0
+                # else:
+                #     self._wr_ptr = self._wr_ptr + 1
+
+    @always_ff((posedge, "clk"), (negedge, "rst_n"))
+    def reg_array_ff(self):
+        if ~self._rst_n:
+            self._reg_array = 0
+        elif self._flush:
+            self._reg_array = 0
+        elif self._clk_en:
+            if self._write:
+                self._reg_array[self._wr_ptr] = self._data_in
+
+    @always_ff((posedge, "clk"), (negedge, "rst_n"))
+    def reg_array_ff_parallel(self):
+        if ~self._rst_n:
+            self._reg_array = 0
+        elif self._flush:
+            self._reg_array = 0
+        elif self._clk_en:
+            if self._parallel_load:
+                self._reg_array = self._parallel_in
+            elif self._write:
+                if self._parallel_read:
+                    self._reg_array[0] = self._data_in
+                else:
+                    self._reg_array[self._wr_ptr] = self._data_in
+
+    @always_comb
+    def data_out_comb(self):
+        if (self._passthru):
+            self._data_out = self._data_in
+        else:
+            self._data_out = self._reg_array[self._rd_ptr]
+
+    @always_comb
+    def valid_comb(self):
+        self._valid = ((~self._empty) | self._passthru)
+        # self._valid = self._pop & ((~self._empty) | self._passthru)
+
+    @always_ff((posedge, "clk"), (negedge, "rst_n"))
+    def set_num_items(self):
+        if ~self._rst_n:
+            self._num_items = 0
+        elif self._flush:
+            self._num_items = resize(self._bogus_init_num, self._num_items.width)
+        elif self._clk_en:
+            if self._write & ~self._read:
+                self._num_items = self._num_items + 1
+            elif ~self._write & self._read:
+                self._num_items = self._num_items - 1
+
+    @always_ff((posedge, "clk"), (negedge, "rst_n"))
+    def set_num_items_parallel(self):
+        if ~self._rst_n:
+            self._num_items = 0
+        elif self._flush:
+            self._num_items = resize(self._bogus_init_num, self._num_items.width)
+        elif self._clk_en:
+            if self._parallel_load:
+                # When fetch width > 1, by definition we cannot load
+                # 0 (only fw or fw - 1), but we need to handle this immediate
+                # pass through in these cases
+                if self._num_load == 0:
+                    self._num_items = self._push.extend(self._num_items.width)
+                else:
+                    self._num_items = self._num_load
+            # One can technically push while a parallel
+            # read is happening...
+            elif self._parallel_read:
+                if self._push:
+                    self._num_items = 1
+                else:
+                    self._num_items = 0
+            elif self._write & ~self._read:
+                self._num_items = self._num_items + 1
+            elif ~self._write & self._read:
+                self._num_items = self._num_items - 1
+
+    def set_min_depth(self):
+        self.set_depth(self.min_depth)
+
+    def update_name(self):
+        self.name = f"cfg_reg_fifo_depth_{self.depth}_w_{self.data_width}_afd_{self.almost_full_diff}{self.mod_name_suffix}"
+
+    def set_depth(self, new_depth):
+        assert not (new_depth & (new_depth - 1)) or new_depth == 0, "Unsupported depth"
+        assert new_depth >= self.min_depth, f"Minimum allowed depth {self.min_depth}: Tried to use {new_depth}"
+        self.depth = new_depth
+        self.ptr_width = max(1, clog2(self.depth))
+        self.update_name()
+        # self.name = f"reg_fifo_depth_{self.depth}_w_{self.data_width}_afd_{self.almost_full_diff}{self.mod_name_suffix}"
+
+    def generate_hardware(self):
+        # Routine to do the real hardware generation once the
+        # parameters have been finalized
+        self.update_name()
+        # self.name = f"reg_fifo_depth_{self.depth}_w_{self.data_width}_afd_{self.almost_full_diff}{self.mod_name_suffix}"
+
+        # Depth of 0 is basically passthru...
+        if self.depth == 0:
+            self.wire(self._data_out, self._data_in)
+            # Data is valid if you are pushing
+            self.wire(self._valid, self._push)
+            # If you are not pushing, it is empty
+            self.wire(self._empty, ~self._push)
+            # It is full if you are not popping
+            self.wire(self._full, ~self._pop)
+            # Almost full cannot be inferred just on the ready/valid interface
+            self.wire(self._almost_full, ~self._pop)
+        else:
+            self._rd_ptr = self.var("rd_ptr", self.ptr_width)
+            if self.break_out_rd_ptr:
+                self.wire(self._rd_ptr_out, self._rd_ptr)
+            self._wr_ptr = self.var("wr_ptr", self.ptr_width)
+            self._read = self.var("read", 1)
+            self._write = self.var("write", 1)
+            self._reg_array = self.var("reg_array",
+                                       self.data_width,
+                                       size=(self.depth,
+                                             self.width_mult),
+                                       packed=True,
+                                       explicit_array=True)
+
+            self._passthru = self.var("passthru", 1)
+
+            self._num_items = self.var("num_items", clog2(self.depth) + 1)
+            # self.wire(self._full, (self._wr_ptr + 1) == self._rd_ptr)
+            self.wire(self._full, self._num_items == self.depth)
+            # Experiment to cover latency
+            assert self.depth > 1 or self.width_mult > 1, "FIFO depth or width_mult needs to be larger than 1"
+            self.wire(self._almost_full, self._num_items >= (self.depth - self.almost_full_diff))
+            # self.wire(self._empty, self._wr_ptr == self._rd_ptr)
+            self.wire(self._empty, self._num_items == 0)
+
+            self.wire(self._read, self._pop & ~self._passthru & ~self._empty)
+
+            # Disallow passthru for now to prevent combinational loops
+            self.wire(self._passthru, const(0, 1))
+            # self.wire(self._passthru, self._pop & self._push & self._empty)
+
+            # Should only write
+
+            # Boilerplate Add always @(posedge clk, ...) blocks
+            if self.parallel:
+                self.add_code(self.set_num_items_parallel)
+                self.add_code(self.reg_array_ff_parallel)
+                self.add_code(self.wr_ptr_ff_parallel)
+                self.add_code(self.rd_ptr_ff_parallel)
+                self.wire(self._parallel_out, self._reg_array)
+                self.wire(self._write,
+                          self._push & ~self._passthru & (~self._full | (self._parallel_read)))
+            else:
+                # self.wire(self._write, self._push & ~self._passthru & (~self._full | self._pop))
+                # Don't want to write when full at all for decoupling
+                self.wire(self._write, self._push & ~self._passthru & (~self._full))
+                self.add_code(self.set_num_items)
+                self.add_code(self.reg_array_ff)
+                self.add_code(self.wr_ptr_ff)
+                self.add_code(self.rd_ptr_ff)
+            self.add_code(self.data_out_comb)
+            self.add_code(self.valid_comb)
+
+        self.hardware_genned = True
+
+    def get_hardware_genned(self):
+        return self.hardware_genned
+    
+      
+
+if __name__ == "__main__":
+    # dut = RegFIFO_cfg(data_width=16,
+    #               depth=64,
+    #               width_mult=4)
+    # verilog(dut, filename="reg_fifo_no_defer.sv")
+
+    dut2 = RegFIFO_cfg(data_width=16,
+                   depth=64,
+                   width_mult=4,
+                   defer_hrdwr_gen=True)
+    dut2.set_depth(8)
+    dut2.generate_hardware()
+
+    verilog(dut2, filename="reg_fifo_with_defer_cfg.sv")

--- a/lake/top/memtile_builder.py
+++ b/lake/top/memtile_builder.py
@@ -1,6 +1,7 @@
 from lake.attributes.hybrid_port_attr import HybridPortAddr
 from lake.modules.chain_accessor import ChainAccessor
 from lake.modules.reg_fifo import RegFIFO
+from lake.modules.reg_fifo_cfg import RegFIFO_cfg
 from lake.top.cgra_tile_builder import CGRATileBuilder
 from lake.modules.storage_config_seq import StorageConfigSeq
 from kratos.stmts import IfStmt
@@ -34,6 +35,9 @@ class MemoryTileBuilder(kts.Generator, CGRATileBuilder):
                  io_prefix=None):
 
         super().__init__(name, debug)
+
+        self.is_PE = 'PE' in name
+        self.is_MEM = 'MemCore' in name 
 
         self.memory_interface = memory_interface
         self.memory_banks = memory_banks
@@ -800,9 +804,17 @@ class MemoryTileBuilder(kts.Generator, CGRATileBuilder):
                     new_input_ready.add_attribute(ControlSignalAttr(False))
 
                     # Add in the fifo if there are any fifos on this path
-                    new_reg_fifo = RegFIFO(data_width=input_width,
-                                           width_mult=1, depth=self.fifo_depth,
-                                           defer_hrdwr_gen=False)
+                    if self.is_PE:
+                        # Create config for bogus init 
+                        input_fifo_bogus_init_num = self.input(f'{self.io_prefix}input_width_{input_width}_num_{i}_fifo_bogus_init_num', width=2)
+                        input_fifo_bogus_init_num.add_attribute(ConfigRegAttr("Choose bogus init num for input fifo"))
+                        new_reg_fifo = RegFIFO_cfg(data_width=input_width,
+                                            width_mult=1, depth=self.fifo_depth,
+                                            defer_hrdwr_gen=False)
+                    else:
+                        new_reg_fifo = RegFIFO(data_width=input_width,
+                                            width_mult=1, depth=self.fifo_depth,
+                                            defer_hrdwr_gen=False)
 
                     self.add_child(f"input_width_{input_width}_num_{i}_input_fifo",
                                    new_reg_fifo,
@@ -827,6 +839,8 @@ class MemoryTileBuilder(kts.Generator, CGRATileBuilder):
                     self.wire(new_input_fifo, new_reg_fifo.ports.data_out)
                     self.wire(new_input_valid_fifo, ~new_reg_fifo.ports.empty)
                     self.wire(new_reg_fifo.ports.pop, new_input_ready_fifo)
+                    if self.is_PE:
+                        self.wire(input_fifo_bogus_init_num, new_reg_fifo.ports.bogus_init_num)
 
                     mux_size = len(rvs)
                     mux_comb = self.combinational()
@@ -967,9 +981,17 @@ class MemoryTileBuilder(kts.Generator, CGRATileBuilder):
                     new_output_ready.add_attribute(ControlSignalAttr(True))
 
                     # Add in the fifo if there are any fifos on this path
-                    new_reg_fifo = RegFIFO(data_width=output_width,
-                                           width_mult=1, depth=self.fifo_depth,
-                                           defer_hrdwr_gen=False)
+                    if self.is_PE:
+                         # Create config for bogus init 
+                        output_fifo_bogus_init_num = self.input(f'{self.io_prefix}output_width_{output_width}_num_{i}_fifo_bogus_init_num', width=2)
+                        output_fifo_bogus_init_num.add_attribute(ConfigRegAttr("Choose bogus init num for output fifo"))
+                        new_reg_fifo = RegFIFO_cfg(data_width=output_width,
+                                            width_mult=1, depth=self.fifo_depth,
+                                            defer_hrdwr_gen=False)
+                    else:  
+                        new_reg_fifo = RegFIFO(data_width=output_width,
+                                            width_mult=1, depth=self.fifo_depth,
+                                            defer_hrdwr_gen=False)
 
                     self.add_child(f"output_width_{output_width}_num_{i}_output_fifo",
                                    new_reg_fifo,
@@ -992,6 +1014,8 @@ class MemoryTileBuilder(kts.Generator, CGRATileBuilder):
                     self.wire(new_output_fifo, new_reg_fifo.ports.data_in)
                     self.wire(new_output_ready_fifo, ~new_reg_fifo.ports.full)
                     self.wire(new_output_valid_fifo, new_reg_fifo.ports.push)
+                    if self.is_PE:
+                        self.wire(output_fifo_bogus_init_num, new_reg_fifo.ports.bogus_init_num)
 
                     # Mux all the inputs to the fifo, broadcast ready back
                     mux_size = len(rvs)


### PR DESCRIPTION
Configurable non-empty PE FIFOs, needed for running dense ready-valid apps. 

Corresponding AHA PR: https://github.com/StanfordAHA/aha/pull/2034